### PR TITLE
Support for ME scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # OSIAM resource server
 
+## Unreleased
+
+### Features
+
+- Support for new `ME` scope
+
 ## 2.0 - 2015-04-29
 
 **Breaking changes!**

--- a/src/main/java/org/osiam/resources/controller/UserController.java
+++ b/src/main/java/org/osiam/resources/controller/UserController.java
@@ -43,11 +43,7 @@ import org.osiam.security.helper.AccessTokenHelper;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriTemplate;
 
 /**
@@ -64,7 +60,7 @@ import org.springframework.web.util.UriTemplate;
 @Controller
 @RequestMapping(value = "/Users")
 @Transactional
-public class  UserController {
+public class UserController {
 
     @Inject
     private SCIMUserProvisioning scimUserProvisioning;
@@ -79,7 +75,7 @@ public class  UserController {
 
     private AttributesRemovalHelper attributesRemovalHelper = new AttributesRemovalHelper();
 
-    @RequestMapping(value = "/{id}", method = RequestMethod.GET) // NOSONAR - duplicate literals unnecessary
+    @RequestMapping(value = "/{id}", method = RequestMethod.GET)
     @ResponseBody
     public User getUser(@PathVariable final String id) {
         return scimUserProvisioning.getById(id);
@@ -100,17 +96,18 @@ public class  UserController {
         return new User.Builder(createdUser).setMeta(newMeta).build();
     }
 
-    @RequestMapping(value = "/{id}", method = RequestMethod.PUT) // NOSONAR - duplicate literals unnecessary
+    @RequestMapping(value = "/{id}", method = RequestMethod.PUT)
     @ResponseStatus(HttpStatus.OK)
     @ResponseBody
-    public User replace(@PathVariable final String id, HttpServletRequest request, HttpServletResponse response) throws IOException {
+    public User replace(@PathVariable final String id, HttpServletRequest request, HttpServletResponse response)
+            throws IOException {
         User user = jsonInputValidator.validateJsonUser(request);
         User createdUser = scimUserProvisioning.replace(id, user);
         checkAndHandleDeactivation(id, user, request);
         return setLocationUriAndCreateUserForOutput(request, response, createdUser);
     }
 
-    @RequestMapping(value = "/{id}", method = RequestMethod.PATCH) // NOSONAR - duplicate literals unnecessary
+    @RequestMapping(value = "/{id}", method = RequestMethod.PATCH)
     @ResponseStatus(HttpStatus.OK)
     @ResponseBody
     public User update(@PathVariable final String id, HttpServletRequest request, HttpServletResponse response)
@@ -121,7 +118,7 @@ public class  UserController {
         return setLocationUriAndCreateUserForOutput(request, response, createdUser);
     }
 
-    @RequestMapping(value = "/{id}", method = RequestMethod.DELETE) // NOSONAR - duplicate literals unnecessary
+    @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
     @ResponseStatus(HttpStatus.OK)
     public void delete(@PathVariable final String id, HttpServletRequest request) {
         scimUserProvisioning.delete(id);
@@ -137,20 +134,18 @@ public class  UserController {
     @RequestMapping(value = "/.search", method = RequestMethod.POST)
     @ResponseBody
     public SCIMSearchResult<User> searchWithPost(HttpServletRequest request) {
-        Map<String,Object> parameterMap = requestParamHelper.getRequestParameterValues(request);
-        SCIMSearchResult<User> scimSearchResult = scimUserProvisioning.search(
-                (String) parameterMap.get("filter"),
+        Map<String, Object> parameterMap = requestParamHelper.getRequestParameterValues(request);
+        SCIMSearchResult<User> scimSearchResult = scimUserProvisioning.search((String) parameterMap.get("filter"),
                 (String) parameterMap.get("sortBy"),
                 (String) parameterMap.get("sortOrder"),
                 (int) parameterMap.get("count"),
-                (int) parameterMap.get("startIndex")
-        );
+                (int) parameterMap.get("startIndex"));
 
         return attributesRemovalHelper.removeSpecifiedUserAttributes(scimSearchResult, parameterMap);
     }
 
     private User setLocationUriAndCreateUserForOutput(HttpServletRequest request, HttpServletResponse response,
-                                                      User createdUser) {
+            User createdUser) {
         String requestUrl = request.getRequestURL().toString();
         response.setHeader("Location", requestUrl);
         Meta newMeta = new Meta.Builder(createdUser.getMeta()).setLocation(requestUrl).build();

--- a/src/main/java/org/osiam/security/authorization/MeScopeAccessDecisionVoter.java
+++ b/src/main/java/org/osiam/security/authorization/MeScopeAccessDecisionVoter.java
@@ -1,0 +1,121 @@
+package org.osiam.security.authorization;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.osiam.resources.scim.User;
+import org.springframework.security.access.AccessDecisionVoter;
+import org.springframework.security.access.ConfigAttribute;
+import org.springframework.security.access.SecurityConfig;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.vote.ScopeVoter;
+import org.springframework.security.web.FilterInvocation;
+
+import com.google.common.base.Splitter;
+
+public class MeScopeAccessDecisionVoter implements AccessDecisionVoter<FilterInvocation> {
+
+    public static final SecurityConfig SCOPE_DYNAMIC = new SecurityConfig("SCOPE_DYNAMIC");
+    public static final SecurityConfig SCOPE_ME = new SecurityConfig("SCOPE_ME");
+
+    private final ScopeVoter scopeVoter;
+
+    public MeScopeAccessDecisionVoter(ScopeVoter scopeVoter) {
+        this.scopeVoter = scopeVoter;
+    }
+
+    @Override
+    public boolean supports(ConfigAttribute attribute) {
+        return attribute.equals(SCOPE_DYNAMIC);
+    }
+
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return FilterInvocation.class.isAssignableFrom(clazz);
+    }
+
+    @Override
+    public int vote(Authentication authentication, FilterInvocation filterInvocation,
+            Collection<ConfigAttribute> attributes) {
+
+        String requestUrl = filterInvocation.getRequestUrl();
+        String requestMethod = filterInvocation.getHttpRequest().getMethod();
+
+        if (!canVoteOn(authentication, requestUrl, requestMethod)) {
+            return ACCESS_ABSTAIN;
+        }
+
+        User user = (User) authentication.getPrincipal();
+
+        if (!isOwnerOfResource(user.getId(), requestUrl)) {
+            return ACCESS_ABSTAIN;
+        }
+
+        return scopeVoter.vote(authentication, filterInvocation, enhanceConfigAttributes(attributes));
+    }
+
+    private Set<ConfigAttribute> enhanceConfigAttributes(Collection<ConfigAttribute> attributes) {
+        Set<ConfigAttribute> enhancedAttributes = new HashSet<>(attributes);
+        if (enhancedAttributes.contains(SCOPE_DYNAMIC)) {
+            enhancedAttributes.remove(SCOPE_DYNAMIC);
+            enhancedAttributes.add(SCOPE_ME);
+        }
+        return enhancedAttributes;
+    }
+
+    private boolean canVoteOn(Authentication authentication, String url, String method) {
+        if (!(authentication instanceof OAuth2Authentication)) {
+            return false;
+        }
+
+        OAuth2Authentication oAuth2Authentication = ((OAuth2Authentication) authentication);
+
+        if (!(oAuth2Authentication.getPrincipal() instanceof User)) {
+            return false;
+        }
+
+        if (!url.startsWith("/Users") && !url.startsWith("/me")) {
+            return false;
+        }
+
+        if (url.startsWith("/Users") && method.equalsIgnoreCase("post")) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private boolean isOwnerOfResource(String userId, String url) {
+        if (url.startsWith("/Users")) {
+            try {
+                String path = new URI(url).getPath();
+                List<String> pathSegments = Splitter.on('/')
+                        .omitEmptyStrings()
+                        .trimResults()
+                        .splitToList(path);
+
+                if (pathSegments.size() < 2) {
+                    return false;
+                }
+
+                String resourceId = pathSegments.get(1);
+                if (userId.equals(resourceId)) {
+                    return true;
+                }
+            } catch (URISyntaxException e) {
+                return false;
+            }
+
+            return false;
+        } else if (url.startsWith("/me")) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/webapp/WEB-INF/resource-server.xml
+++ b/src/main/webapp/WEB-INF/resource-server.xml
@@ -28,100 +28,87 @@
         http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd
         http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd">
 
-    <!-- Resource Service interface secured via OAuth2 -->
     <http pattern="/" create-session="never" entry-point-ref="oauthAuthenticationEntryPoint"
           access-decision-manager-ref="accessDecisionManager" xmlns="http://www.springframework.org/schema/security">
 
-        <!-- resources below /secured/get/resource/ are accessed via scope "READ" -->
         <intercept-url pattern="/**" access="SCOPE_DYNAMIC"/>
-
-        <!-- validates the delivered access token -->
         <custom-filter ref="resourceServerFilter" before="PRE_AUTH_FILTER"/>
-
-        <!-- uses general oauthAccessDeniedHandler -->
         <access-denied-handler ref="oauthAccessDeniedHandler"/>
     </http>
 
     <http pattern="/Users/**" create-session="never" entry-point-ref="oauthAuthenticationEntryPoint"
           access-decision-manager-ref="accessDecisionManager" xmlns="http://www.springframework.org/schema/security">
 
-        <!-- resources below /secured/get/resource/ are accessed via scope "READ" -->
         <intercept-url pattern="/Users/**" access="SCOPE_DYNAMIC"/>
-
-        <!-- validates the delivered access token -->
         <custom-filter ref="resourceServerFilter" before="PRE_AUTH_FILTER"/>
+        <access-denied-handler ref="oauthAccessDeniedHandler"/>
+    </http>
 
-        <!-- uses general oauthAccessDeniedHandler -->
+    <http pattern="/me/**" create-session="never" entry-point-ref="oauthAuthenticationEntryPoint"
+          access-decision-manager-ref="accessDecisionManager" xmlns="http://www.springframework.org/schema/security">
+
+        <intercept-url pattern="/me/**" access="SCOPE_DYNAMIC"/>
+        <custom-filter ref="resourceServerFilter" before="PRE_AUTH_FILTER"/>
         <access-denied-handler ref="oauthAccessDeniedHandler"/>
     </http>
 
     <http pattern="/Groups/**" create-session="never" entry-point-ref="oauthAuthenticationEntryPoint"
           access-decision-manager-ref="accessDecisionManager" xmlns="http://www.springframework.org/schema/security">
 
-        <!-- resources below /secured/get/resource/ are accessed via scope "READ" -->
         <intercept-url pattern="/Groups/**" access="SCOPE_DYNAMIC"/>
-
-        <!-- validates the delivered access token -->
         <custom-filter ref="resourceServerFilter" before="PRE_AUTH_FILTER"/>
-
-        <!-- uses general oauthAccessDeniedHandler -->
         <access-denied-handler ref="oauthAccessDeniedHandler"/>
     </http>
 
     <http pattern="/Metrics/**" create-session="never" entry-point-ref="oauthAuthenticationEntryPoint"
           access-decision-manager-ref="accessDecisionManager" xmlns="http://www.springframework.org/schema/security">
 
-        <!-- resources below /secured/get/resource/ are accessed via scope "READ" -->
         <intercept-url pattern="/Metrics/**" access="SCOPE_DYNAMIC"/>
-
-        <!-- validates the delivered access token -->
         <custom-filter ref="resourceServerFilter" before="PRE_AUTH_FILTER"/>
-
-        <!-- uses general oauthAccessDeniedHandler -->
         <access-denied-handler ref="oauthAccessDeniedHandler"/>
     </http>
 
     <http pattern="/osiam/**" create-session="never" entry-point-ref="oauthAuthenticationEntryPoint"
           access-decision-manager-ref="accessDecisionManager" xmlns="http://www.springframework.org/schema/security">
 
-        <!-- resources below /secured/get/resource/ are accessed via scope "READ" -->
         <intercept-url pattern="/osiam/**" access="SCOPE_DYNAMIC"/>
-
-        <!-- validates the delivered access token -->
         <custom-filter ref="resourceServerFilter" before="PRE_AUTH_FILTER"/>
-
-        <!-- uses general oauthAccessDeniedHandler -->
         <access-denied-handler ref="oauthAccessDeniedHandler"/>
     </http>
 
-    <!-- entry point for OAuth2 secured resources -->
+    <authentication-manager xmlns="http://www.springframework.org/schema/security"/>
+
+    <oauth:resource-server id="resourceServerFilter" resource-id="oauth2res"
+                           token-services-ref="accessTokenValidationService"/>
+
     <bean id="oauthAuthenticationEntryPoint"
           class="org.springframework.security.oauth2.provider.error.OAuth2AuthenticationEntryPoint">
+
         <property name="realmName" value="oauth2-authorization-server"/>
     </bean>
 
-    <!-- general access decision manager for OAuth2 secured resources -->
-    <bean id="accessDecisionManager" class="org.springframework.security.access.vote.AffirmativeBased"
-          xmlns="http://www.springframework.org/schema/beans">
+    <bean id="scopeVoter" class="org.springframework.security.oauth2.provider.vote.ScopeVoter">
+        <property name="throwException" value="false"/>
+    </bean>
+
+    <bean id="accessDecisionManager" class="org.springframework.security.access.vote.AffirmativeBased">
+        <property name="allowIfAllAbstainDecisions" value="false"/>
+
         <constructor-arg>
             <list>
+                <bean class="org.osiam.security.authorization.MeScopeAccessDecisionVoter">
+                    <constructor-arg ref="scopeVoter"/>
+                </bean>
                 <bean class="org.osiam.security.authorization.DynamicHTTPMethodScopeEnhancer">
-                    <constructor-arg>
-                        <bean class="org.springframework.security.oauth2.provider.vote.ScopeVoter"/>
-                    </constructor-arg>
+                    <constructor-arg ref="scopeVoter"/>
                 </bean>
             </list>
         </constructor-arg>
     </bean>
 
-    <authentication-manager xmlns="http://www.springframework.org/schema/security" />
-
     <bean id="passwordEncoder" class="org.springframework.security.authentication.encoding.ShaPasswordEncoder">
         <constructor-arg value="512"/>
         <property name="iterations" value="1000"/>
     </bean>
-
-    <!-- filter to validate the delivered access token -->
-    <oauth:resource-server id="resourceServerFilter" resource-id="oauth2res" token-services-ref="accessTokenValidationService"/>
 
 </beans>


### PR DESCRIPTION
`ME` is a scope that allows read and write access to the data of the user associated with the access token.

This includes:
- Retrieving the complete User resource
- Modifying all attributes of the User resource
- Deleting the User resource
- Revoking the access tokens of the User
- Access the `/me` resource
- Validate the access token

Note that this only works with a user-bound access token, i.e. a token with scope `ME` that has been retrieved via client credentials grant **CANNOT** access any user's data.
