### PR TITLE
Only set `UserEntity#active` id value is not null

### DIFF
--- a/src/main/java/org/osiam/resources/converter/UserConverter.java
+++ b/src/main/java/org/osiam/resources/converter/UserConverter.java
@@ -93,7 +93,10 @@ public class UserConverter implements Converter<User, UserEntity> {
             userEntity.setPassword(user.getPassword());
         }
 
-        userEntity.setActive(user.isActive());
+        if(user.isActive() != null) {
+            userEntity.setActive(user.isActive());
+        }
+
         userEntity.setDisplayName(user.getDisplayName());
         userEntity.setNickName(user.getNickName());
         userEntity.setExternalId(user.getExternalId() == null ? null : user.getExternalId().isEmpty() ? null : user

--- a/src/test/groovy/org/osiam/resources/converter/UserConverterSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/converter/UserConverterSpec.groovy
@@ -153,6 +153,19 @@ class UserConverterSpec extends Specification {
         userConverter.toScim(null) == null
     }
 
+    def 'SCIM User without active field set results in entity with active set to false'() {
+        given:
+        extensionConverter.fromScim(_) >> ([] as Set)
+        User user = new User.Builder('irrelevant')
+                .build()
+
+        when:
+        UserEntity userEntity = userConverter.fromScim(user)
+
+        then:
+        userEntity.getActive() == false
+    }
+
     def User getFilledUser(UUID internalId) {
         User.Builder userBuilder = new User.Builder(fixtures)
         userBuilder.setId(internalId.toString())


### PR DESCRIPTION
Otherwise the default value of the field will be used, which is
`Boolean.FALSE`.

fixes osiam/auth-server#8
