### PR TITLE
Fix outdated URN-String-Literals

### DIFF
--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -311,7 +311,7 @@ the response will be the created user.
 e.g.:
 
 ```sh
-curl -i -H "Accept: application/json" -H "Content-type: application/json" -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" -X POST http://localhost:8080/osiam-resource-server/Users -d '{"schemas":["urn:scim:schemas:core:2.0:User"],"externalId":"external_id","userName":"arthur","password":"dent"}'
+curl -i -H "Accept: application/json" -H "Content-type: application/json" -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" -X POST http://localhost:8080/osiam-resource-server/Users -d '{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],"externalId":"external_id","userName":"arthur","password":"dent"}'
 ```
 
 See [scim 2 rest spec]
@@ -330,7 +330,7 @@ the response will be the replaced user in json format.
 
 e.g.:
 ```sh
-curl -i -H "Accept: application/json" -H "Content-type: application/json" -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" -X PUT http://localhost:8080/osiam-resource-server/Users/$ID -d '{"schemas":["urn:scim:schemas:core:2.0:User"], "externalId":"new_external_id","userName":"arthur","password":"dent"}'
+curl -i -H "Accept: application/json" -H "Content-type: application/json" -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" -X PUT http://localhost:8080/osiam-resource-server/Users/$ID -d '{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"], "externalId":"new_external_id","userName":"arthur","password":"dent"}'
 ```
 
 See [scim 2 rest spec]
@@ -349,7 +349,7 @@ the response will be the updated user in json format.
 
 e.g.:
 ```sh
-curl -i -H "Accept: application/json" -H "Content-type: application/json" -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" -X PATCH http://localhost:8080/osiam-resource-server/Users/$ID -d '{"schemas":["urn:scim:schemas:core:2.0:User"], "externalId":"new_external_id"}'
+curl -i -H "Accept: application/json" -H "Content-type: application/json" -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" -X PATCH http://localhost:8080/osiam-resource-server/Users/$ID -d '{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"], "externalId":"new_external_id"}'
 ```
 See [scim 2 rest spec]
 (http://tools.ietf.org/html/draft-ietf-scim-api-02#section-3.3.2) for further
@@ -407,7 +407,7 @@ the response will be the created group in json format.
 e.g.:
 
 ```sh
-curl -i -H "Accept: application/json" -H "Content-type: application/json" -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" -X POST http://localhost:8080/osiam-resource-server/Groups -d '{"schemas":["urn:scim:schemas:core:2.0:Group"],"displayName":"adminsGroup"}'
+curl -i -H "Accept: application/json" -H "Content-type: application/json" -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" -X POST http://localhost:8080/osiam-resource-server/Groups -d '{"schemas":["urn:ietf:params:scim:schemas:core:2.0:Group"],"displayName":"adminsGroup"}'
 ```
 
 See [scim 2 rest spec]
@@ -426,7 +426,7 @@ the response will be the replaced group in json format.
 e.g.:
 
 ```sh
-curl -i -H "Accept: application/json" -H "Content-type: application/json" -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" -X PUT http://localhost:8080/osiam-resource-server/Groups/$ID -d '{"schemas":["urn:scim:schemas:core:2.0:Group"], "displayName":"Group1"}'
+curl -i -H "Accept: application/json" -H "Content-type: application/json" -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" -X PUT http://localhost:8080/osiam-resource-server/Groups/$ID -d '{"schemas":["urn:ietf:params:scim:schemas:core:2.0:Group"], "displayName":"Group1"}'
 ```
 See [scim 2 rest spec]
 (http://tools.ietf.org/html/draft-ietf-scim-api-02#section-3.3.1) for further
@@ -445,7 +445,7 @@ the response will be the updated group in json format.
 e.g.:
 
 ```sh
-curl -i -H "Accept: application/json" -H "Content-type: application/json" -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" -X PATCH http://localhost:8080/osiam-resource-server/Groups/$ID -d '{"schemas":["urn:scim:schemas:core:2.0:Group"], "displayName":"adminsGroup"}'
+curl -i -H "Accept: application/json" -H "Content-type: application/json" -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" -X PATCH http://localhost:8080/osiam-resource-server/Groups/$ID -d '{"schemas":["urn:ietf:params:scim:schemas:core:2.0:Group"], "displayName":"adminsGroup"}'
 ```
 See [scim 2 rest spec]
 (http://tools.ietf.org/html/draft-ietf-scim-api-02#section-3.3.2) for further

--- a/src/test/groovy/org/osiam/resources/controller/ShowComplexAttributeFilterSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/controller/ShowComplexAttributeFilterSpec.groovy
@@ -27,6 +27,7 @@ import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import org.osiam.resources.helper.RequestParamHelper
 import org.osiam.resources.provisioning.SCIMUserProvisioning
+import org.osiam.resources.scim.Constants
 import org.osiam.resources.scim.Meta
 import org.osiam.resources.scim.SCIMSearchResult
 import org.osiam.resources.scim.User
@@ -47,7 +48,7 @@ class ShowComplexAttributeFilterSpec extends Specification {
         def created = dateTimeFormatter.print(date)
 
         def user = new User.Builder("username").setMeta(new Meta.Builder(actualDate, null).build()).build()
-        def scimSearchResult = new SCIMSearchResult([user] as List, 23, 100, 0, ["urn:scim:schemas:core:2.0:User"] as Set)
+        def scimSearchResult = new SCIMSearchResult([user] as List, 23, 100, 0, [Constants.USER_CORE_SCHEMA] as Set)
         when:
         def result = underTest.searchWithPost(servletRequestMock)
 
@@ -55,10 +56,10 @@ class ShowComplexAttributeFilterSpec extends Specification {
         2 * servletRequestMock.getParameter("attributes") >> "meta.created"
         1 * provisioning.search(_, _, _, _, _) >> scimSearchResult
 
-        result.getResources() == [[meta: [created: created], schemas: ['urn:scim:schemas:core:2.0:User']]] as List
+        result.getResources() == [[meta: [created: created], schemas: [Constants.USER_CORE_SCHEMA]]] as List
         result.getItemsPerPage() == 100
         result.getStartIndex() == 0
         result.getTotalResults() == 23
-        result.getSchemas() == ["urn:scim:schemas:core:2.0:User"] as Set
+        result.getSchemas() == [Constants.USER_CORE_SCHEMA] as Set
     }
 }

--- a/src/test/groovy/org/osiam/resources/helper/AttributesRemovalHelperSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/helper/AttributesRemovalHelperSpec.groovy
@@ -25,6 +25,7 @@ package org.osiam.resources.helper
 
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
+import org.osiam.resources.scim.Constants
 import org.osiam.resources.scim.Meta
 import org.osiam.resources.scim.SCIMSearchResult
 import org.osiam.resources.scim.User
@@ -60,7 +61,7 @@ class AttributesRemovalHelperSpec extends Specification {
     def "should return Json string with additional values for searches on users, groups and filtering for userName"() {
         given:
         def user = new User.Builder("username").setSchemas([
-                "urn:scim:schemas:core:2.0:User"] as Set).build()
+                Constants.USER_CORE_SCHEMA] as Set).build()
         def userList = [user] as List<User>
         def parameterMapMock = Mock(Map)
         def attributes = ["userName"] as String[]
@@ -79,13 +80,13 @@ class AttributesRemovalHelperSpec extends Specification {
         result.startIndex == 0
         result.itemsPerPage == 0
         result.totalResults == 1337
-        result.getResources() == [[schemas: ['urn:scim:schemas:core:2.0:User'], userName: 'username']]
+        result.getResources() == [[schemas: [Constants.USER_CORE_SCHEMA], userName: 'username']]
     }
 
     def "should not filter the search result if attributes are empty"() {
         given:
         def user = new User.Builder("username").setSchemas([
-                "schemas:urn:scim:schemas:core:1.0"] as Set).build()
+                "schemas:urn:ietf:params:scim:schemas:core:2.0"] as Set).build()
         def userList = [user] as List<User>
         def parameterMapMock = Mock(Map)
         def attributes = [] as String[]
@@ -106,14 +107,14 @@ class AttributesRemovalHelperSpec extends Specification {
         result.totalResults == 1337
         result.getResources() == [
                 ["schemas"   : [
-                        "schemas:urn:scim:schemas:core:1.0"
+                        "schemas:urn:ietf:params:scim:schemas:core:2.0"
                 ], "userName": "username"]] as List
     }
 
     def "should return only data of a complex type"() {
         given:
         def set = [
-                "urn:scim:schemas:core:2.0:User"] as Set
+                Constants.USER_CORE_SCHEMA] as Set
         String[] pA = ["meta", "created"]
         def param = ["attributes": pA, "count": 23, "startIndex": 23]
 
@@ -132,8 +133,8 @@ class AttributesRemovalHelperSpec extends Specification {
         result.startIndex == 1
         result.itemsPerPage == 23
         result.totalResults == 1
-        result.getResources() == [[meta: [created: created], schemas: ['urn:scim:schemas:core:2.0:User']]] as List
+        result.getResources() == [[meta: [created: created], schemas: [Constants.USER_CORE_SCHEMA]]] as List
         result.getSchemas() == [
-                'urn:scim:schemas:core:2.0:User'] as Set
+                Constants.USER_CORE_SCHEMA] as Set
     }
 }

--- a/src/test/groovy/org/osiam/resources/helper/IsoDateFormatSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/helper/IsoDateFormatSpec.groovy
@@ -27,6 +27,7 @@ import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import org.osiam.resources.controller.UserController
 import org.osiam.resources.provisioning.SCIMUserProvisioning
+import org.osiam.resources.scim.Constants
 import org.osiam.resources.scim.Meta
 import org.osiam.resources.scim.SCIMSearchResult
 import org.osiam.resources.scim.User
@@ -48,7 +49,7 @@ class IsoDateFormatSpec extends Specification {
         def created = dateTimeFormatter.print(date)
 
         def user = new User.Builder("username").setMeta(new Meta.Builder(actualDate, null).build()).build()
-        def scimSearchResult = new SCIMSearchResult([user] as List, 23, 100, 0, ["urn:scim:schemas:core:1.0"] as Set)
+        def scimSearchResult = new SCIMSearchResult([user] as List, 23, 100, 0, ["urn:ietf:params:scim:schemas:core:2.0"] as Set)
 
         when:
         def result = userController.searchWithGet(servletRequestMock)
@@ -57,10 +58,10 @@ class IsoDateFormatSpec extends Specification {
         2 * servletRequestMock.getParameter("attributes") >> "meta.created"
         1 * provisioning.search(_, _, _, _, _) >> scimSearchResult
 
-        result.getResources() == [[meta: [created: created], schemas: ['urn:scim:schemas:core:2.0:User']]] as List
+        result.getResources() == [[meta: [created: created], schemas: [Constants.USER_CORE_SCHEMA]]] as List
         result.getItemsPerPage() == 100
         result.getStartIndex() == 0
         result.getTotalResults() == 23
-        result.getSchemas() == ["urn:scim:schemas:core:1.0"] as Set
+        result.getSchemas() == ["urn:ietf:params:scim:schemas:core:2.0"] as Set
     }
 }


### PR DESCRIPTION
Related to: osiam/scim-schema#144

Use constants from `org.osiam.resources.scim.Constants` where possible.

Also updates the documentation-files.
