### PR TITLE
Make the generated errors SCIM spec compliant again.

### DIFF
--- a/src/main/java/org/osiam/resources/exception/OsiamExceptionHandler.java
+++ b/src/main/java/org/osiam/resources/exception/OsiamExceptionHandler.java
@@ -26,7 +26,6 @@ package org.osiam.resources.exception;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
-import org.osiam.resources.exception.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -116,25 +115,31 @@ public class OsiamExceptionHandler extends ResponseEntityExceptionHandler {
         if (transformer != null) {
             message = transformer.transform(message);
         }
-        return new JsonErrorResult(status.name(), message);
+        return new JsonErrorResult(status, message);
     }
 
     @JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
     static class JsonErrorResult {
-        private String error_code;
-        private String description;
+        public static final String ERROR_URN = "urn:ietf:params:scim:api:messages:2.0:Error";
+        private String[] schemas = {ERROR_URN};
+        private String status;
+        private String detail;
 
-        public JsonErrorResult(String name, String message) {
-            error_code = name;
-            description = message;
+        public JsonErrorResult(HttpStatus name, String message) {
+            status = name.toString();
+            detail = message;
         }
 
-        public String getError_code() {
-            return error_code;
+        public String[] getSchemas() {
+            return schemas;
         }
 
-        public String getDescription() {
-            return description;
+        public String getStatus() {
+            return status;
+        }
+
+        public String getDetail() {
+            return detail;
         }
     }
 }

--- a/src/test/groovy/org/osiam/resources/exception/OsiamExceptionHandlerSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/exception/OsiamExceptionHandlerSpec.groovy
@@ -24,7 +24,6 @@
 package org.osiam.resources.exception
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import org.osiam.resources.exception.OsiamExceptionHandler
 import org.osiam.resources.scim.User
 import org.springframework.http.HttpStatus
 import spock.lang.Specification
@@ -39,55 +38,55 @@ class OsiamExceptionHandlerSpec extends Specification {
         when:
         def result = exceptionHandler.defaultExceptionHandler(new NullPointerException(IRRELEVANT))
         then:
-        result.error_code == HttpStatus.CONFLICT.name()
-        result.description == "An unexpected error occurred"
+        result.status == HttpStatus.CONFLICT.toString()
+        result.detail == "An unexpected error occurred"
     }
 
     def 'status is set to BAD_REQUEST when InvalidConstraintException occurs'() {
         when:
         def result = exceptionHandler.handleInvalidConstraintException(new InvalidConstraintException(IRRELEVANT))
         then:
-        result.description == "Constraint ${IRRELEVANT} is invalid"
-        result.error_code == HttpStatus.BAD_REQUEST.name()
+        result.detail == "Constraint ${IRRELEVANT} is invalid"
+        result.status == HttpStatus.BAD_REQUEST.toString()
     }
 
     def 'status is set to INTERNAL_SERVER_ERROR when BackendFailureException occurs'() {
         when:
         def result = exceptionHandler.handleBackendFailure(new OsiamBackendFailureException())
         then:
-        result.description == "An internal error occurred"
-        result.error_code == HttpStatus.INTERNAL_SERVER_ERROR.name()
+        result.detail == "An internal error occurred"
+        result.status == HttpStatus.INTERNAL_SERVER_ERROR.toString()
     }
 
     def 'status is set to CONFLICT when ResourceExistsException occurs'() {
         when:
         def result = exceptionHandler.handleResourceExists(new ResourceExistsException(IRRELEVANT))
         then:
-        result.error_code == HttpStatus.CONFLICT.name()
-        result.description == IRRELEVANT
+        result.status == HttpStatus.CONFLICT.toString()
+        result.detail == IRRELEVANT
     }
 
     def 'status is set to NOT_FOUND when ResourceNotFoundException occurs'() {
         when:
         def result = exceptionHandler.handleResourceNotFoundException(new ResourceNotFoundException(IRRELEVANT))
         then:
-        result.error_code == HttpStatus.NOT_FOUND.name()
-        result.description == IRRELEVANT
+        result.status == HttpStatus.NOT_FOUND.toString()
+        result.detail == IRRELEVANT
     }
 
     def "status is set to NOT_IMPLEMENTED when java.lang.UnsupportedOperationException occurs"() {
         when:
         def result = exceptionHandler.handleUnsupportedOperation(new UnsupportedOperationException(IRRELEVANT))
         then:
-        result.error_code == HttpStatus.NOT_IMPLEMENTED.name()
-        result.description == IRRELEVANT
+        result.status == HttpStatus.NOT_IMPLEMENTED.toString()
+        result.detail == IRRELEVANT
     }
 
     def "status is set to I_AM_A_TEAPOT when org.osiam.resources.exceptions.SchemaUnknownException occurs"() {
         when:
         def result = exceptionHandler.handleSchemaUnknown(new SchemaUnknownException())
         then:
-        result.error_code == HttpStatus.I_AM_A_TEAPOT.name()
+        result.status == HttpStatus.I_AM_A_TEAPOT.toString()
     }
 
     def "should transform json property invalid error message to a more readable response"() {
@@ -96,8 +95,8 @@ class OsiamExceptionHandlerSpec extends Specification {
         when:
         def result = exceptionHandler.handleUnrecognizedProperty(e)
         then:
-        result.error_code == HttpStatus.CONFLICT.name()
-        result.description == 'Unrecognized field "extId"'
+        result.status == HttpStatus.CONFLICT.toString()
+        result.detail == 'Unrecognized field "extId"'
     }
 
     def "should transform json mapping error for List to a more readable response"() {
@@ -106,8 +105,8 @@ class OsiamExceptionHandlerSpec extends Specification {
         when:
         def result = exceptionHandler.handleJsonMapping(e)
         then:
-        result.description == 'Can not deserialize instance of java.util.ArrayList out of VALUE_STRING'
-        result.error_code == HttpStatus.CONFLICT.name()
+        result.detail == 'Can not deserialize instance of java.util.ArrayList out of VALUE_STRING'
+        result.status == HttpStatus.CONFLICT.toString()
     }
 
     Exception generate_wrong_json_exception(String input, Class clazz) {


### PR DESCRIPTION
The generated errors were not compliant to the [SCIM specification](https://tools.ietf.org/html/draft-ietf-scim-api-19#page-55) anymore. This PR makes them more compliant again. It does not however implement the optional `scimType` attribute for `400 BAD_REQUEST` responses. That is left for a later pull request. Closes #37
