### PR TITLE
Remove use of Constants interface

### DIFF
--- a/src/main/java/org/osiam/resources/controller/ServiceProviderConfigsController.java
+++ b/src/main/java/org/osiam/resources/controller/ServiceProviderConfigsController.java
@@ -26,7 +26,7 @@ package org.osiam.resources.controller;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.osiam.resources.scim.Constants;
+import org.osiam.resources.helper.RequestParamHelper;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -47,9 +47,10 @@ public class ServiceProviderConfigsController {
     public static final class ServiceProviderConfig {
 
         public static final ServiceProviderConfig INSTANCE = new ServiceProviderConfig();
+        public static final String SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig";
         public final Supported patch = new Supported(true);
         public final Supported bulk = new BulkSupported(false);
-        public final Supported filter = new FilterSupported(true, Constants.MAX_RESULT);
+        public final Supported filter = new FilterSupported(true, RequestParamHelper.MAX_RESULT);
         public final Supported changePassword = new Supported(false);
         public final Supported sort = new Supported(true);
         public final Supported etag = new Supported(false);
@@ -61,7 +62,7 @@ public class ServiceProviderConfigsController {
         public Set<String> schemas = new HashSet<>();
 
         private ServiceProviderConfig() {
-            schemas.add(Constants.SERVICE_PROVIDER_CORE_SCHEMA);
+            schemas.add(SCHEMA);
         }
 
         @JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)

--- a/src/main/java/org/osiam/resources/helper/AttributesRemovalHelper.java
+++ b/src/main/java/org/osiam/resources/helper/AttributesRemovalHelper.java
@@ -31,7 +31,6 @@ import com.fasterxml.jackson.databind.ser.FilterProvider;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import org.osiam.resources.exception.OsiamBackendFailureException;
-import org.osiam.resources.scim.Constants;
 import org.osiam.resources.scim.Resource;
 import org.osiam.resources.scim.SCIMSearchResult;
 import org.osiam.resources.scim.User;
@@ -133,7 +132,7 @@ public class AttributesRemovalHelper {
         List<String> returnFields = Arrays.asList(fieldsToReturn);
         for (User resource : resourceList) {
             for (String schema : resource.getSchemas()) {
-                if (schema.equals(Constants.USER_CORE_SCHEMA) || returnFields.contains(schema)) {
+                if (schema.equals(User.SCHEMA) || returnFields.contains(schema)) {
                     newSchema.add(schema);
                 }
             }

--- a/src/main/java/org/osiam/resources/helper/JsonInputValidator.java
+++ b/src/main/java/org/osiam/resources/helper/JsonInputValidator.java
@@ -35,7 +35,6 @@ import org.osiam.resources.helper.validators.PatchValidator;
 import org.osiam.resources.helper.validators.PostValidator;
 import org.osiam.resources.helper.validators.PutValidator;
 import org.osiam.resources.helper.validators.Validator;
-import org.osiam.resources.scim.Constants;
 import org.osiam.resources.scim.Group;
 import org.osiam.resources.scim.User;
 import org.springframework.stereotype.Service;
@@ -75,7 +74,7 @@ public class JsonInputValidator {
             throw new IllegalArgumentException("The JSON structure is invalid", ex);
         }
         if (user.getSchemas() == null || user.getSchemas().isEmpty()
-                || !user.getSchemas().contains(Constants.USER_CORE_SCHEMA)) {
+                || !user.getSchemas().contains(User.SCHEMA)) {
             throw new SchemaUnknownException();
         }
         if (user.getId() != null && !user.getId().isEmpty()) {
@@ -94,7 +93,7 @@ public class JsonInputValidator {
             throw new IllegalArgumentException("The JSON structure is invalid", ex);
         }
         if (group.getSchemas() == null || group.getSchemas().isEmpty()
-                || !group.getSchemas().contains(Constants.GROUP_CORE_SCHEMA)) {
+                || !group.getSchemas().contains(Group.SCHEMA)) {
             throw new SchemaUnknownException();
         }
         return group;

--- a/src/main/java/org/osiam/resources/helper/RequestParamHelper.java
+++ b/src/main/java/org/osiam/resources/helper/RequestParamHelper.java
@@ -28,9 +28,9 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.osiam.resources.scim.Constants;
-
 public class RequestParamHelper {
+
+    public static final int MAX_RESULT = 100;
 
     public Map<String, Object> getRequestParameterValues(HttpServletRequest request) {
 
@@ -57,7 +57,7 @@ public class RequestParamHelper {
     }
 
     private void validateCount(HttpServletRequest request, Map<String, Object> parameterMap) {
-        int count = Constants.MAX_RESULT;
+        int count = MAX_RESULT;
         if (request.getParameter("count") != null) {
             count = Integer.parseInt(request.getParameter("count"));
         }

--- a/src/main/java/org/osiam/resources/provisioning/SCIMGroupProvisioning.java
+++ b/src/main/java/org/osiam/resources/provisioning/SCIMGroupProvisioning.java
@@ -35,7 +35,6 @@ import org.osiam.resources.converter.GroupConverter;
 import org.osiam.resources.exception.ResourceExistsException;
 import org.osiam.resources.exception.ResourceNotFoundException;
 import org.osiam.resources.provisioning.update.GroupUpdater;
-import org.osiam.resources.scim.Constants;
 import org.osiam.resources.scim.Group;
 import org.osiam.resources.scim.SCIMSearchResult;
 import org.osiam.storage.dao.GroupDao;
@@ -118,7 +117,7 @@ public class SCIMGroupProvisioning implements SCIMProvisioning<Group> {
             groups.add(groupConverter.toScim(group));
         }
 
-        return new SCIMSearchResult<>(groups, result.totalResults, count, startIndex, Constants.LIST_RESPONSE_CORE_SCHEMA);
+        return new SCIMSearchResult<>(groups, result.totalResults, count, startIndex);
     }
 
     @Override

--- a/src/main/java/org/osiam/resources/provisioning/SCIMUserProvisioning.java
+++ b/src/main/java/org/osiam/resources/provisioning/SCIMUserProvisioning.java
@@ -35,7 +35,6 @@ import org.osiam.resources.converter.UserConverter;
 import org.osiam.resources.exception.ResourceExistsException;
 import org.osiam.resources.exception.ResourceNotFoundException;
 import org.osiam.resources.provisioning.update.UserUpdater;
-import org.osiam.resources.scim.Constants;
 import org.osiam.resources.scim.SCIMSearchResult;
 import org.osiam.resources.scim.User;
 import org.osiam.storage.dao.SearchResult;
@@ -158,7 +157,7 @@ public class SCIMUserProvisioning implements SCIMProvisioning<User> {
             users.add(getUserWithoutPassword(scimResultUser));
         }
 
-        return new SCIMSearchResult<>(users, result.totalResults, count, startIndex, Constants.LIST_RESPONSE_CORE_SCHEMA);
+        return new SCIMSearchResult<>(users, result.totalResults, count, startIndex);
     }
 
     private boolean searchedForPasswordAndNoResult(SearchResult<UserEntity> result, String filter) {

--- a/src/test/groovy/org/osiam/resources/controller/ServiceProviderConfigSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/controller/ServiceProviderConfigSpec.groovy
@@ -23,7 +23,6 @@
 
 package org.osiam.resources.controller
 
-import org.osiam.resources.scim.Constants
 import spock.lang.Specification
 
 class ServiceProviderConfigSpec extends Specification {
@@ -32,7 +31,7 @@ class ServiceProviderConfigSpec extends Specification {
     def "should return a ServiceProviderConfig"() {
         given:
         def schemas = [
-                Constants.SERVICE_PROVIDER_CORE_SCHEMA] as Set
+                ServiceProviderConfigsController.ServiceProviderConfig.SCHEMA] as Set
 
         when:
         def config = underTest.getConfig()

--- a/src/test/groovy/org/osiam/resources/controller/ShowComplexAttributeFilterSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/controller/ShowComplexAttributeFilterSpec.groovy
@@ -27,7 +27,6 @@ import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import org.osiam.resources.helper.RequestParamHelper
 import org.osiam.resources.provisioning.SCIMUserProvisioning
-import org.osiam.resources.scim.Constants
 import org.osiam.resources.scim.Meta
 import org.osiam.resources.scim.SCIMSearchResult
 import org.osiam.resources.scim.User
@@ -48,7 +47,7 @@ class ShowComplexAttributeFilterSpec extends Specification {
         def created = dateTimeFormatter.print(date)
 
         def user = new User.Builder("username").setMeta(new Meta.Builder(actualDate, null).build()).build()
-        def scimSearchResult = new SCIMSearchResult([user] as List, 23, 100, 0, [Constants.USER_CORE_SCHEMA] as Set)
+        def scimSearchResult = new SCIMSearchResult([user] as List, 23, 100, 0)
         when:
         def result = underTest.searchWithPost(servletRequestMock)
 
@@ -56,10 +55,10 @@ class ShowComplexAttributeFilterSpec extends Specification {
         2 * servletRequestMock.getParameter("attributes") >> "meta.created"
         1 * provisioning.search(_, _, _, _, _) >> scimSearchResult
 
-        result.getResources() == [[meta: [created: created], schemas: [Constants.USER_CORE_SCHEMA]]] as List
+        result.getResources() == [[meta: [created: created], schemas: [User.SCHEMA]]] as List
         result.getItemsPerPage() == 100
         result.getStartIndex() == 0
         result.getTotalResults() == 23
-        result.getSchemas() == [Constants.USER_CORE_SCHEMA] as Set
+        result.getSchemas() == [SCIMSearchResult.SCHEMA] as Set
     }
 }

--- a/src/test/groovy/org/osiam/resources/helper/AttributesRemovalHelperSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/helper/AttributesRemovalHelperSpec.groovy
@@ -25,7 +25,6 @@ package org.osiam.resources.helper
 
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
-import org.osiam.resources.scim.Constants
 import org.osiam.resources.scim.Meta
 import org.osiam.resources.scim.SCIMSearchResult
 import org.osiam.resources.scim.User
@@ -61,7 +60,7 @@ class AttributesRemovalHelperSpec extends Specification {
     def "should return Json string with additional values for searches on users, groups and filtering for userName"() {
         given:
         def user = new User.Builder("username").setSchemas([
-                Constants.USER_CORE_SCHEMA] as Set).build()
+                User.SCHEMA] as Set).build()
         def userList = [user] as List<User>
         def parameterMapMock = Mock(Map)
         def attributes = ["userName"] as String[]
@@ -80,7 +79,7 @@ class AttributesRemovalHelperSpec extends Specification {
         result.startIndex == 0
         result.itemsPerPage == 0
         result.totalResults == 1337
-        result.getResources() == [[schemas: [Constants.USER_CORE_SCHEMA], userName: 'username']]
+        result.getResources() == [[schemas: [User.SCHEMA], userName: 'username']]
     }
 
     def "should not filter the search result if attributes are empty"() {
@@ -113,8 +112,6 @@ class AttributesRemovalHelperSpec extends Specification {
 
     def "should return only data of a complex type"() {
         given:
-        def set = [
-                Constants.USER_CORE_SCHEMA] as Set
         String[] pA = ["meta", "created"]
         def param = ["attributes": pA, "count": 23, "startIndex": 23]
 
@@ -124,7 +121,7 @@ class AttributesRemovalHelperSpec extends Specification {
         def created = dateTimeFormatter.print(date)
 
         def user = new User.Builder("username").setMeta(new Meta.Builder(actualDate, null).build()).build()
-        def scimSearchResult = new SCIMSearchResult([user], 1, 23, 1, set)
+        def scimSearchResult = new SCIMSearchResult([user], 1, 23, 1)
 
         when:
         def result = attributesRemovalHelperTest.removeSpecifiedAttributes(scimSearchResult, param)
@@ -133,8 +130,7 @@ class AttributesRemovalHelperSpec extends Specification {
         result.startIndex == 1
         result.itemsPerPage == 23
         result.totalResults == 1
-        result.getResources() == [[meta: [created: created], schemas: [Constants.USER_CORE_SCHEMA]]] as List
-        result.getSchemas() == [
-                Constants.USER_CORE_SCHEMA] as Set
+        result.getResources() == [[meta: [created: created], schemas: [User.SCHEMA]]] as List
+        result.getSchemas() == [SCIMSearchResult.SCHEMA] as Set
     }
 }

--- a/src/test/groovy/org/osiam/resources/helper/IsoDateFormatSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/helper/IsoDateFormatSpec.groovy
@@ -27,7 +27,6 @@ import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import org.osiam.resources.controller.UserController
 import org.osiam.resources.provisioning.SCIMUserProvisioning
-import org.osiam.resources.scim.Constants
 import org.osiam.resources.scim.Meta
 import org.osiam.resources.scim.SCIMSearchResult
 import org.osiam.resources.scim.User
@@ -49,7 +48,7 @@ class IsoDateFormatSpec extends Specification {
         def created = dateTimeFormatter.print(date)
 
         def user = new User.Builder("username").setMeta(new Meta.Builder(actualDate, null).build()).build()
-        def scimSearchResult = new SCIMSearchResult([user] as List, 23, 100, 0, ["urn:ietf:params:scim:schemas:core:2.0"] as Set)
+        def scimSearchResult = new SCIMSearchResult([user] as List, 23, 100, 0)
 
         when:
         def result = userController.searchWithGet(servletRequestMock)
@@ -58,10 +57,10 @@ class IsoDateFormatSpec extends Specification {
         2 * servletRequestMock.getParameter("attributes") >> "meta.created"
         1 * provisioning.search(_, _, _, _, _) >> scimSearchResult
 
-        result.getResources() == [[meta: [created: created], schemas: [Constants.USER_CORE_SCHEMA]]] as List
+        result.getResources() == [[meta: [created: created], schemas: [User.SCHEMA]]] as List
         result.getItemsPerPage() == 100
         result.getStartIndex() == 0
         result.getTotalResults() == 23
-        result.getSchemas() == ["urn:ietf:params:scim:schemas:core:2.0"] as Set
+        result.getSchemas() == [SCIMSearchResult.SCHEMA] as Set
     }
 }

--- a/src/test/groovy/org/osiam/resources/helper/JsonInputValidatorSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/helper/JsonInputValidatorSpec.groovy
@@ -24,7 +24,8 @@
 package org.osiam.resources.helper
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import org.osiam.resources.scim.Constants
+import org.osiam.resources.scim.Group
+import org.osiam.resources.scim.User
 import spock.lang.Specification
 
 import javax.servlet.http.HttpServletRequest
@@ -41,7 +42,7 @@ class JsonInputValidatorSpec extends Specification {
 
     def 'validating user if JSON is valid works'() {
         given:
-        def userJson = """{"userName":"irrelevant","password": "123","schemas" : ["$Constants.USER_CORE_SCHEMA"]}"""
+        def userJson = """{"userName":"irrelevant","password": "123","schemas" : ["$User.SCHEMA"]}"""
         readerMock.readLine() >>> [userJson, null]
 
         when:
@@ -53,7 +54,7 @@ class JsonInputValidatorSpec extends Specification {
 
     def 'missing mandatory userName raises exception'() {
         given:
-        def userJson = """{"schemas" : ["$Constants.USER_CORE_SCHEMA"]}"""
+        def userJson = """{"schemas" : ["$User.SCHEMA"]}"""
         readerMock.readLine() >>> [userJson, null]
 
         when:
@@ -77,7 +78,7 @@ class JsonInputValidatorSpec extends Specification {
 
     def 'using PATCH without userName field works'() {
         given:
-        def userJson = """{"password":"123", "schemas" : ["$Constants.USER_CORE_SCHEMA"]}"""
+        def userJson = """{"password":"123", "schemas" : ["$User.SCHEMA"]}"""
         servletRequestWithMethod 'PATCH'
         readerMock.readLine() >>> [userJson, null]
 
@@ -87,7 +88,7 @@ class JsonInputValidatorSpec extends Specification {
 
     def 'validating invalid JSON structure raises exception'() {
         given:
-        def userJson = """{"schemas":["$Constants.USER_CORE_SCHEMA"],"userName":"irrelevant","password":"123"""
+        def userJson = """{"schemas":["$User.SCHEMA"],"userName":"irrelevant","password":"123"""
         readerMock.readLine() >>> [userJson, null]
 
         when:
@@ -99,7 +100,7 @@ class JsonInputValidatorSpec extends Specification {
 
     def 'removing uuid from user when using POST works'() {
         given:
-        def userJson = """{"id":"irrelevant","schemas":["$Constants.USER_CORE_SCHEMA"],"userName":"irrelevant","password":"123"}"""
+        def userJson = """{"id":"irrelevant","schemas":["$User.SCHEMA"],"userName":"irrelevant","password":"123"}"""
         readerMock.readLine() >>> [userJson, null]
 
         when:
@@ -111,7 +112,7 @@ class JsonInputValidatorSpec extends Specification {
 
     def 'validating group if JSON is valid works'() {
         given:
-        def groupJson = """{"schemas":["$Constants.GROUP_CORE_SCHEMA"],"displayName":"display name"}"""
+        def groupJson = """{"schemas":["$Group.SCHEMA"],"displayName":"display name"}"""
         readerMock.readLine() >>> [groupJson, null]
 
         when:
@@ -123,7 +124,7 @@ class JsonInputValidatorSpec extends Specification {
 
     def 'missing mandatory displayName raises exception'() {
         given:
-        def groupJson = """{"schemas":["$Constants.GROUP_CORE_SCHEMA"],"members": []}"""
+        def groupJson = """{"schemas":["$Group.SCHEMA"],"members": []}"""
         readerMock.readLine() >>> [groupJson, null]
 
         when:
@@ -135,7 +136,7 @@ class JsonInputValidatorSpec extends Specification {
 
     def 'using PATCH without displayName works'() {
         given:
-        def groupJson = """{"schemas":["$Constants.GROUP_CORE_SCHEMA"],"members": []}"""
+        def groupJson = """{"schemas":["$Group.SCHEMA"],"members": []}"""
         servletRequestWithMethod 'PATCH'
         readerMock.readLine() >>> [groupJson, null]
 


### PR DESCRIPTION
Remove use of the constants interface from the scim-schema since this is
going  to be removed. This is necessary since osiam/scim-schema#150 got rid of the `Constants` interface. It also cleans up the code a little.
