### PR TITLE
Clean up code

### DIFF
--- a/src/main/java/org/osiam/resources/converter/ExtensionConverter.java
+++ b/src/main/java/org/osiam/resources/converter/ExtensionConverter.java
@@ -23,13 +23,7 @@
 
 package org.osiam.resources.converter;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
+import com.google.common.base.Strings;
 import org.osiam.resources.scim.Extension;
 import org.osiam.resources.scim.ExtensionFieldType;
 import org.osiam.storage.dao.ExtensionDao;
@@ -40,16 +34,25 @@ import org.osiam.storage.helper.NumberPadder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.google.common.base.Strings;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 @Service
 public class ExtensionConverter implements Converter<Set<Extension>, Set<ExtensionFieldValueEntity>> {
 
-    @Autowired
     private ExtensionDao extensionDao;
 
-    @Autowired
     private NumberPadder numberPadder;
+
+    @Autowired
+    public ExtensionConverter(ExtensionDao extensionDao) {
+        this.extensionDao = extensionDao;
+        this.numberPadder = new NumberPadder();
+    }
 
     @Override
     public Set<ExtensionFieldValueEntity> fromScim(Set<Extension> extensions) {
@@ -129,7 +132,7 @@ public class ExtensionConverter implements Converter<Set<Extension>, Set<Extensi
     }
 
     private <T> void addField(Extension.Builder extensionBuilder, ExtensionFieldType<T> type, String fieldName,
-            String stringValue) {
+                              String stringValue) {
         extensionBuilder.setField(fieldName, type.fromString(stringValue), type);
     }
 }

--- a/src/main/java/org/osiam/resources/provisioning/SCIMExtensionProvisioning.java
+++ b/src/main/java/org/osiam/resources/provisioning/SCIMExtensionProvisioning.java
@@ -31,8 +31,12 @@ public class SCIMExtensionProvisioning {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SCIMExtensionProvisioning.class);
 
-    @Autowired
     private ExtensionDao dao;
+
+    @Autowired
+    public SCIMExtensionProvisioning(ExtensionDao dao) {
+        this.dao = dao;
+    }
 
     /**
      * Get all persisted extension definitions.

--- a/src/main/java/org/osiam/resources/provisioning/SCIMGroupProvisioning.java
+++ b/src/main/java/org/osiam/resources/provisioning/SCIMGroupProvisioning.java
@@ -23,13 +23,6 @@
 
 package org.osiam.resources.provisioning;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-
-import javax.persistence.NoResultException;
-import javax.persistence.PersistenceException;
-
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.osiam.resources.converter.GroupConverter;
 import org.osiam.resources.exception.ResourceExistsException;
@@ -46,6 +39,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import javax.persistence.NoResultException;
+import javax.persistence.PersistenceException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
 @Service
 public class SCIMGroupProvisioning implements SCIMProvisioning<Group> {
 
@@ -59,9 +58,6 @@ public class SCIMGroupProvisioning implements SCIMProvisioning<Group> {
 
     @Autowired
     private GroupUpdater groupUpdater;
-
-    @Autowired
-    private QueryFilterParser queryFilterParser;
 
     @Override
     public Group create(Group group) {
@@ -106,6 +102,7 @@ public class SCIMGroupProvisioning implements SCIMProvisioning<Group> {
 
     @Override
     public SCIMSearchResult<Group> search(String filter, String sortBy, String sortOrder, int count, int startIndex) {
+        QueryFilterParser queryFilterParser = new QueryFilterParser();
         List<Group> groups = new ArrayList<>();
 
         ParseTree filterTree = queryFilterParser.getParseTree(filter);

--- a/src/main/java/org/osiam/resources/provisioning/SCIMUserProvisioning.java
+++ b/src/main/java/org/osiam/resources/provisioning/SCIMUserProvisioning.java
@@ -65,9 +65,6 @@ public class SCIMUserProvisioning implements SCIMProvisioning<User> {
     @Autowired
     private UserUpdater userUpdater;
 
-    @Autowired
-    private QueryFilterParser queryFilterParser;
-
     @Override
     public User getById(String id) {
         try {
@@ -143,6 +140,7 @@ public class SCIMUserProvisioning implements SCIMProvisioning<User> {
 
     @Override
     public SCIMSearchResult<User> search(String filter, String sortBy, String sortOrder, int count, int startIndex) {
+        QueryFilterParser queryFilterParser = new QueryFilterParser();
         List<User> users = new ArrayList<>();
 
         ParseTree filterTree = queryFilterParser.getParseTree(filter);

--- a/src/main/java/org/osiam/resources/provisioning/update/AddressUpdater.java
+++ b/src/main/java/org/osiam/resources/provisioning/update/AddressUpdater.java
@@ -23,9 +23,7 @@
 
 package org.osiam.resources.provisioning.update;
 
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.base.Strings;
 import org.osiam.resources.converter.AddressConverter;
 import org.osiam.resources.scim.Address;
 import org.osiam.storage.entities.AddressEntity;
@@ -33,7 +31,8 @@ import org.osiam.storage.entities.UserEntity;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.google.common.base.Strings;
+import java.util.List;
+import java.util.Set;
 
 /**
  * The AddressUpdater provides the functionality to update the {@link AddressEntity} of a UserEntity
@@ -41,19 +40,20 @@ import com.google.common.base.Strings;
 @Service
 class AddressUpdater {
 
-    @Autowired
     private AddressConverter addressConverter;
+
+    @Autowired
+    public AddressUpdater(AddressConverter addressConverter) {
+        this.addressConverter = addressConverter;
+    }
 
     /**
      * updates (adds new, delete, updates) the addresses of the given {@link UserEntity} based on the given List of
      * {@link Address}
-     * 
-     * @param addresss
-     *            list of {@link Address} to be deleted, updated or added
-     * @param userEntity
-     *            user who needs to be updated
-     * @param attributes
-     *            all {@link AddressEntity}'s will be deleted if this Set contains 'address'
+     *
+     * @param addresss   list of {@link Address} to be deleted, updated or added
+     * @param userEntity user who needs to be updated
+     * @param attributes all {@link AddressEntity}'s will be deleted if this Set contains 'address'
      */
     void update(List<Address> addresss, UserEntity userEntity, Set<String> attributes) {
 
@@ -65,7 +65,7 @@ class AddressUpdater {
             for (Address scimAddress : addresss) {
                 AddressEntity addressEntity = addressConverter.fromScim(scimAddress);
                 userEntity.removeAddress(addressEntity); // we always have to remove the address in case
-                                                         // the primary attribute has changed
+                // the primary attribute has changed
                 if (Strings.isNullOrEmpty(scimAddress.getOperation())
                         || !scimAddress.getOperation().equalsIgnoreCase("delete")) {
 
@@ -79,11 +79,9 @@ class AddressUpdater {
     /**
      * if the given newAddress is set to primary the primary attribute of all existing address's in the
      * {@link UserEntity} will be removed
-     * 
-     * @param newAddress
-     *            to be checked if it is primary
-     * @param addresss
-     *            all existing address's of the {@link UserEntity}
+     *
+     * @param newAddress to be checked if it is primary
+     * @param addresss   all existing address's of the {@link UserEntity}
      */
     private void ensureOnlyOnePrimaryAddressExists(AddressEntity newAddress, Set<AddressEntity> addresss) {
         if (newAddress.isPrimary()) {

--- a/src/main/java/org/osiam/resources/provisioning/update/EmailUpdater.java
+++ b/src/main/java/org/osiam/resources/provisioning/update/EmailUpdater.java
@@ -23,9 +23,7 @@
 
 package org.osiam.resources.provisioning.update;
 
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.base.Strings;
 import org.osiam.resources.converter.EmailConverter;
 import org.osiam.resources.scim.Email;
 import org.osiam.storage.entities.EmailEntity;
@@ -33,7 +31,8 @@ import org.osiam.storage.entities.UserEntity;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.google.common.base.Strings;
+import java.util.List;
+import java.util.Set;
 
 /**
  * The EmailUpdater provides the functionality to update the {@link EmailEntity} of a UserEntity
@@ -41,19 +40,20 @@ import com.google.common.base.Strings;
 @Service
 class EmailUpdater {
 
-    @Autowired
     private EmailConverter emailConverter;
+
+    @Autowired
+    public EmailUpdater(EmailConverter emailConverter) {
+        this.emailConverter = emailConverter;
+    }
 
     /**
      * updates (adds new, delete, updates) the {@link EmailEntity}'s of the given {@link UserEntity} based on the given
      * List of Email's
-     * 
-     * @param emails
-     *            list of Email's to be deleted, updated or added
-     * @param userEntity
-     *            user who needs to be updated
-     * @param attributes
-     *            all {@link EmailEntity}'s will be deleted if this Set contains 'emails'
+     *
+     * @param emails     list of Email's to be deleted, updated or added
+     * @param userEntity user who needs to be updated
+     * @param attributes all {@link EmailEntity}'s will be deleted if this Set contains 'emails'
      */
     void update(List<Email> emails, UserEntity userEntity, Set<String> attributes) {
 
@@ -65,7 +65,7 @@ class EmailUpdater {
             for (Email scimEmail : emails) {
                 EmailEntity emailEntity = emailConverter.fromScim(scimEmail);
                 userEntity.removeEmail(emailEntity); // we always have to remove the email in case
-                                                     // the primary attribute has changed
+                // the primary attribute has changed
                 if (Strings.isNullOrEmpty(scimEmail.getOperation())
                         || !scimEmail.getOperation().equalsIgnoreCase("delete")) {
 
@@ -79,11 +79,9 @@ class EmailUpdater {
     /**
      * if the given newEmail is set to primary the primary attribute of all existing email's in the {@link UserEntity}
      * will be removed
-     * 
-     * @param newEmail
-     *            to be checked if it is primary
-     * @param emails
-     *            all existing email's of the {@link UserEntity}
+     *
+     * @param newEmail to be checked if it is primary
+     * @param emails   all existing email's of the {@link UserEntity}
      */
     private void ensureOnlyOnePrimaryEmailExists(EmailEntity newEmail, Set<EmailEntity> emails) {
         if (newEmail.isPrimary()) {

--- a/src/main/java/org/osiam/resources/provisioning/update/EntitlementsUpdater.java
+++ b/src/main/java/org/osiam/resources/provisioning/update/EntitlementsUpdater.java
@@ -23,9 +23,7 @@
 
 package org.osiam.resources.provisioning.update;
 
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.base.Strings;
 import org.osiam.resources.converter.EntitlementConverter;
 import org.osiam.resources.scim.Entitlement;
 import org.osiam.storage.entities.EntitlementEntity;
@@ -33,7 +31,8 @@ import org.osiam.storage.entities.UserEntity;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.google.common.base.Strings;
+import java.util.List;
+import java.util.Set;
 
 /**
  * The EntitlementsUpdater provides the functionality to update the {@link EntitlementEntity} of a UserEntity
@@ -41,19 +40,20 @@ import com.google.common.base.Strings;
 @Service
 class EntitlementsUpdater {
 
-    @Autowired
     private EntitlementConverter entitlementConverter;
+
+    @Autowired
+    public EntitlementsUpdater(EntitlementConverter entitlementConverter) {
+        this.entitlementConverter = entitlementConverter;
+    }
 
     /**
      * updates (adds new, delete, updates) the {@link EntitlementEntity}'s of the given {@link UserEntity} based on the
      * given List of Entitlement's
-     * 
-     * @param entitlements
-     *            list of Entitlement's to be deleted, updated or added
-     * @param userEntity
-     *            user who needs to be updated
-     * @param attributes
-     *            all {@link EntitlementEntity}'s will be deleted if this Set contains 'entitlements'
+     *
+     * @param entitlements list of Entitlement's to be deleted, updated or added
+     * @param userEntity   user who needs to be updated
+     * @param attributes   all {@link EntitlementEntity}'s will be deleted if this Set contains 'entitlements'
      */
     void update(List<Entitlement> entitlements, UserEntity userEntity, Set<String> attributes) {
 
@@ -65,7 +65,7 @@ class EntitlementsUpdater {
             for (Entitlement scimEntitlements : entitlements) {
                 EntitlementEntity entitlementsEntity = entitlementConverter.fromScim(scimEntitlements);
                 userEntity.removeEntitlement(entitlementsEntity); // we always have to remove the entitlement's in case
-                                                                  // the primary attribute has changed
+                // the primary attribute has changed
                 if (Strings.isNullOrEmpty(scimEntitlements.getOperation())
                         || !scimEntitlements.getOperation().equalsIgnoreCase("delete")) {
 
@@ -79,14 +79,12 @@ class EntitlementsUpdater {
     /**
      * if the given newEntitlement is set to primary the primary attribute of all existing entitlement's in the
      * {@link UserEntity} will be removed
-     * 
-     * @param newEntitlement
-     *            to be checked if it is primary
-     * @param entitlements
-     *            all existing entitlement's of the {@link UserEntity}
+     *
+     * @param newEntitlement to be checked if it is primary
+     * @param entitlements   all existing entitlement's of the {@link UserEntity}
      */
     private void ensureOnlyOnePrimaryEntitlementExists(EntitlementEntity newEntitlement,
-            Set<EntitlementEntity> entitlements) {
+                                                       Set<EntitlementEntity> entitlements) {
         if (newEntitlement.isPrimary()) {
             for (EntitlementEntity exisitngEntitlementEntity : entitlements) {
                 if (exisitngEntitlementEntity.isPrimary()) {

--- a/src/main/java/org/osiam/resources/provisioning/update/ExtensionUpdater.java
+++ b/src/main/java/org/osiam/resources/provisioning/update/ExtensionUpdater.java
@@ -52,11 +52,15 @@ class ExtensionUpdater {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ExtensionUpdater.class);
 
-    @Autowired
     private ExtensionDao extensionDao;
 
-    @Autowired
     private NumberPadder numberPadder;
+
+    @Autowired
+    public ExtensionUpdater(ExtensionDao extensionDao) {
+        this.extensionDao = extensionDao;
+        this.numberPadder = new NumberPadder();
+    }
 
     /**
      * updates (remove, updates) the {@link ExtensionEntity}'s of the given {@link UserEntity} based on the given List
@@ -109,7 +113,7 @@ class ExtensionUpdater {
         ExtensionEntity extensionEntity = extensionDao.getExtensionByUrn(urn);
 
         for (String fieldName : updatedScimExtension.getFields().keySet()) {
-            ExtensionFieldEntity extensionEntitiyField = null;
+            ExtensionFieldEntity extensionEntitiyField;
             try {
                 extensionEntitiyField = extensionEntity.getFieldForName(fieldName, true);
             } catch (NoSuchElementException e) {

--- a/src/main/java/org/osiam/resources/provisioning/update/GroupUpdater.java
+++ b/src/main/java/org/osiam/resources/provisioning/update/GroupUpdater.java
@@ -23,9 +23,7 @@
 
 package org.osiam.resources.provisioning.update;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import com.google.common.base.Strings;
 import org.osiam.resources.exception.ResourceExistsException;
 import org.osiam.resources.scim.Group;
 import org.osiam.resources.scim.MemberRef;
@@ -36,7 +34,8 @@ import org.osiam.storage.entities.ResourceEntity;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.google.common.base.Strings;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * The GroupUpdater provides the functionality to update (patch) a {@link GroupEntity}
@@ -44,22 +43,24 @@ import com.google.common.base.Strings;
 @Service
 public class GroupUpdater {
 
-    @Autowired
     private GroupDao groupDao;
 
-    @Autowired
     private ResourceUpdater resourceUpdater;
 
-    @Autowired
     private ResourceDao resourceDao;
+
+    @Autowired
+    public GroupUpdater(GroupDao groupDao, ResourceUpdater resourceUpdater, ResourceDao resourceDao) {
+        this.groupDao = groupDao;
+        this.resourceUpdater = resourceUpdater;
+        this.resourceDao = resourceDao;
+    }
 
     /**
      * updates the {@link GroupEntity} based on the given {@link Group}
      *
-     * @param group
-     *            group with all fields that needs to be updated
-     * @param groupEntity
-     *            entity that needs to be updated
+     * @param group       group with all fields that needs to be updated
+     * @param groupEntity entity that needs to be updated
      */
     public void update(Group group, GroupEntity groupEntity) {
         resourceUpdater.update(group, groupEntity);

--- a/src/main/java/org/osiam/resources/provisioning/update/ImUpdater.java
+++ b/src/main/java/org/osiam/resources/provisioning/update/ImUpdater.java
@@ -23,17 +23,16 @@
 
 package org.osiam.resources.provisioning.update;
 
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.base.Strings;
 import org.osiam.resources.converter.ImConverter;
+import org.osiam.resources.scim.Im;
 import org.osiam.storage.entities.ImEntity;
 import org.osiam.storage.entities.UserEntity;
-import org.osiam.resources.scim.Im;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.google.common.base.Strings;
+import java.util.List;
+import java.util.Set;
 
 /**
  * The ImUpdater provides the functionality to update the {@link ImEntity} of a UserEntity
@@ -41,19 +40,20 @@ import com.google.common.base.Strings;
 @Service
 class ImUpdater {
 
-    @Autowired
     private ImConverter imConverter;
+
+    @Autowired
+    public ImUpdater(ImConverter imConverter) {
+        this.imConverter = imConverter;
+    }
 
     /**
      * updates (adds new, delete, updates) the {@link ImEntity}'s of the given {@link UserEntity} based on the given
      * List of Im's
-     * 
-     * @param ims
-     *            list of Im's to be deleted, updated or added
-     * @param userEntity
-     *            user who needs to be updated
-     * @param attributes
-     *            all {@link ImEntity}'s will be deleted if this Set contains 'ims'
+     *
+     * @param ims        list of Im's to be deleted, updated or added
+     * @param userEntity user who needs to be updated
+     * @param attributes all {@link ImEntity}'s will be deleted if this Set contains 'ims'
      */
     void update(List<Im> ims, UserEntity userEntity, Set<String> attributes) {
 
@@ -65,7 +65,7 @@ class ImUpdater {
             for (Im scimIm : ims) {
                 ImEntity imEntity = imConverter.fromScim(scimIm);
                 userEntity.removeIm(imEntity); // we always have to remove the im in case
-                                               // the primary attribute has changed
+                // the primary attribute has changed
                 if (Strings.isNullOrEmpty(scimIm.getOperation())
                         || !scimIm.getOperation().equalsIgnoreCase("delete")) {
 
@@ -79,11 +79,9 @@ class ImUpdater {
     /**
      * if the given newIm is set to primary the primary attribute of all existing im's in the {@link UserEntity} will be
      * removed
-     * 
-     * @param newIm
-     *            to be checked if it is primary
-     * @param ims
-     *            all existing im's of the {@link UserEntity}
+     *
+     * @param newIm to be checked if it is primary
+     * @param ims   all existing im's of the {@link UserEntity}
      */
     private void ensureOnlyOnePrimaryImExists(ImEntity newIm, Set<ImEntity> ims) {
         if (newIm.isPrimary()) {

--- a/src/main/java/org/osiam/resources/provisioning/update/PhoneNumberUpdater.java
+++ b/src/main/java/org/osiam/resources/provisioning/update/PhoneNumberUpdater.java
@@ -23,17 +23,16 @@
 
 package org.osiam.resources.provisioning.update;
 
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.base.Strings;
 import org.osiam.resources.converter.PhoneNumberConverter;
+import org.osiam.resources.scim.PhoneNumber;
 import org.osiam.storage.entities.PhoneNumberEntity;
 import org.osiam.storage.entities.UserEntity;
-import org.osiam.resources.scim.PhoneNumber;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.google.common.base.Strings;
+import java.util.List;
+import java.util.Set;
 
 /**
  * The PhoneNumberUpdater provides the functionality to update the {@link PhoneNumberEntity} of a UserEntity
@@ -41,19 +40,20 @@ import com.google.common.base.Strings;
 @Service
 class PhoneNumberUpdater {
 
-    @Autowired
     private PhoneNumberConverter phoneNumberConverter;
+
+    @Autowired
+    public PhoneNumberUpdater(PhoneNumberConverter phoneNumberConverter) {
+        this.phoneNumberConverter = phoneNumberConverter;
+    }
 
     /**
      * updates (adds new, delete, updates) the {@link PhoneNumberEntity}'s of the given {@link UserEntity} based on the
      * given List of PhoneNumber's
-     * 
-     * @param phoneNumbers
-     *            list of PhoneNumber's to be deleted, updated or added
-     * @param userEntity
-     *            user who needs to be updated
-     * @param attributes
-     *            all {@link PhoneNumberEntity}'s will be deleted if this Set contains 'phoneNumbers'
+     *
+     * @param phoneNumbers list of PhoneNumber's to be deleted, updated or added
+     * @param userEntity   user who needs to be updated
+     * @param attributes   all {@link PhoneNumberEntity}'s will be deleted if this Set contains 'phoneNumbers'
      */
     void update(List<PhoneNumber> phoneNumbers, UserEntity userEntity, Set<String> attributes) {
 
@@ -65,7 +65,7 @@ class PhoneNumberUpdater {
             for (PhoneNumber scimPhoneNumber : phoneNumbers) {
                 PhoneNumberEntity phoneNumberEntity = phoneNumberConverter.fromScim(scimPhoneNumber);
                 userEntity.removePhoneNumber(phoneNumberEntity); // we always have to remove the phoneNumber in case
-                                                                 // the primary attribute has changed
+                // the primary attribute has changed
                 if (Strings.isNullOrEmpty(scimPhoneNumber.getOperation())
                         || !scimPhoneNumber.getOperation().equalsIgnoreCase("delete")) {
 
@@ -79,14 +79,12 @@ class PhoneNumberUpdater {
     /**
      * if the given newPhoneNumber is set to primary the primary attribute of all existing phoneNumber's in the
      * {@link UserEntity} will be removed
-     * 
-     * @param newPhoneNumber
-     *            to be checked if it is primary
-     * @param phoneNumbers
-     *            all existing phoneNumber's of the {@link UserEntity}
+     *
+     * @param newPhoneNumber to be checked if it is primary
+     * @param phoneNumbers   all existing phoneNumber's of the {@link UserEntity}
      */
     private void ensureOnlyOnePrimaryPhoneNumberExists(PhoneNumberEntity newPhoneNumber,
-            Set<PhoneNumberEntity> phoneNumbers) {
+                                                       Set<PhoneNumberEntity> phoneNumbers) {
         if (newPhoneNumber.isPrimary()) {
             for (PhoneNumberEntity exisitngPhoneNumberEntity : phoneNumbers) {
                 if (exisitngPhoneNumberEntity.isPrimary()) {

--- a/src/main/java/org/osiam/resources/provisioning/update/PhotoUpdater.java
+++ b/src/main/java/org/osiam/resources/provisioning/update/PhotoUpdater.java
@@ -23,17 +23,16 @@
 
 package org.osiam.resources.provisioning.update;
 
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.base.Strings;
 import org.osiam.resources.converter.PhotoConverter;
+import org.osiam.resources.scim.Photo;
 import org.osiam.storage.entities.PhotoEntity;
 import org.osiam.storage.entities.UserEntity;
-import org.osiam.resources.scim.Photo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.google.common.base.Strings;
+import java.util.List;
+import java.util.Set;
 
 /**
  * The PhotoUpdater provides the functionality to update the {@link PhotoEntity} of a UserEntity
@@ -41,19 +40,20 @@ import com.google.common.base.Strings;
 @Service
 class PhotoUpdater {
 
-    @Autowired
     private PhotoConverter photoConverter;
+
+    @Autowired
+    public PhotoUpdater(PhotoConverter photoConverter) {
+        this.photoConverter = photoConverter;
+    }
 
     /**
      * updates (adds new, delete, updates) the {@link PhotoEntity}'s of the given {@link UserEntity} based on the given
      * List of Photo's
-     * 
-     * @param photos
-     *            list of Photo's to be deleted, updated or added
-     * @param userEntity
-     *            user who needs to be updated
-     * @param attributes
-     *            all {@link PhotoEntity}'s will be deleted if this Set contains 'photos'
+     *
+     * @param photos     list of Photo's to be deleted, updated or added
+     * @param userEntity user who needs to be updated
+     * @param attributes all {@link PhotoEntity}'s will be deleted if this Set contains 'photos'
      */
     void update(List<Photo> photos, UserEntity userEntity, Set<String> attributes) {
 
@@ -65,7 +65,7 @@ class PhotoUpdater {
             for (Photo scimPhoto : photos) {
                 PhotoEntity photoEntity = photoConverter.fromScim(scimPhoto);
                 userEntity.removePhoto(photoEntity); // we always have to remove the photo in case
-                                                     // the primary attribute has changed
+                // the primary attribute has changed
                 if (Strings.isNullOrEmpty(scimPhoto.getOperation())
                         || !scimPhoto.getOperation().equalsIgnoreCase("delete")) {
 
@@ -79,11 +79,9 @@ class PhotoUpdater {
     /**
      * if the given newPhoto is set to primary the primary attribute of all existing photo's in the {@link UserEntity}
      * will be removed
-     * 
-     * @param newPhoto
-     *            to be checked if it is primary
-     * @param photos
-     *            all existing photo's of the {@link UserEntity}
+     *
+     * @param newPhoto to be checked if it is primary
+     * @param photos   all existing photo's of the {@link UserEntity}
      */
     private void ensureOnlyOnePrimaryPhotoExists(PhotoEntity newPhoto, Set<PhotoEntity> photos) {
         if (newPhoto.isPrimary()) {

--- a/src/main/java/org/osiam/resources/provisioning/update/ResourceUpdater.java
+++ b/src/main/java/org/osiam/resources/provisioning/update/ResourceUpdater.java
@@ -36,16 +36,18 @@ import org.springframework.stereotype.Service;
 @Service
 public class ResourceUpdater {
 
-    @Autowired
     private ResourceDao resourceDao;
+
+    @Autowired
+    public ResourceUpdater(ResourceDao resourceDao) {
+        this.resourceDao = resourceDao;
+    }
 
     /**
      * updates (adds new, delete, updates) the given {@link ResourceEntity} based on the given {@link Resource}
      *
-     * @param resource
-     *            {@link Resource} to be deleted, updated or added
-     * @param resourceEntity
-     *            {@link ResourceEntity} which will be updated
+     * @param resource       {@link Resource} to be deleted, updated or added
+     * @param resourceEntity {@link ResourceEntity} which will be updated
      */
     public void update(Resource resource, ResourceEntity resourceEntity) {
 

--- a/src/main/java/org/osiam/resources/provisioning/update/RoleUpdater.java
+++ b/src/main/java/org/osiam/resources/provisioning/update/RoleUpdater.java
@@ -23,17 +23,16 @@
 
 package org.osiam.resources.provisioning.update;
 
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.base.Strings;
 import org.osiam.resources.converter.RoleConverter;
+import org.osiam.resources.scim.Role;
 import org.osiam.storage.entities.RoleEntity;
 import org.osiam.storage.entities.UserEntity;
-import org.osiam.resources.scim.Role;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.google.common.base.Strings;
+import java.util.List;
+import java.util.Set;
 
 /**
  * The RoleUpdater provides the functionality to update the {@link RoleEntity} of a UserEntity
@@ -41,19 +40,20 @@ import com.google.common.base.Strings;
 @Service
 class RoleUpdater {
 
-    @Autowired
     private RoleConverter roleConverter;
+
+    @Autowired
+    public RoleUpdater(RoleConverter roleConverter) {
+        this.roleConverter = roleConverter;
+    }
 
     /**
      * updates (adds new, delete, updates) the {@link RoleEntity}'s of the given {@link UserEntity} based on the given
      * List of Role's
-     * 
-     * @param roles
-     *            list of Role's to be deleted, updated or added
-     * @param userEntity
-     *            user who needs to be updated
-     * @param attributes
-     *            all {@link RoleEntity}'s will be deleted if this Set contains 'roles'
+     *
+     * @param roles      list of Role's to be deleted, updated or added
+     * @param userEntity user who needs to be updated
+     * @param attributes all {@link RoleEntity}'s will be deleted if this Set contains 'roles'
      */
     void update(List<Role> roles, UserEntity userEntity, Set<String> attributes) {
 
@@ -65,7 +65,7 @@ class RoleUpdater {
             for (Role scimRole : roles) {
                 RoleEntity roleEntity = roleConverter.fromScim(scimRole);
                 userEntity.removeRole(roleEntity); // we always have to remove the role in case
-                                                   // the primary attribute has changed
+                // the primary attribute has changed
                 if (Strings.isNullOrEmpty(scimRole.getOperation())
                         || !scimRole.getOperation().equalsIgnoreCase("delete")) {
 
@@ -79,11 +79,9 @@ class RoleUpdater {
     /**
      * if the given newRole is set to primary the primary attribute of all existing role's in the {@link UserEntity}
      * will be removed
-     * 
-     * @param newRole
-     *            to be checked if it is primary
-     * @param roles
-     *            all existing role's of the {@link UserEntity}
+     *
+     * @param newRole to be checked if it is primary
+     * @param roles   all existing role's of the {@link UserEntity}
      */
     private void ensureOnlyOnePrimaryRoleExists(RoleEntity newRole, Set<RoleEntity> roles) {
         if (newRole.isPrimary()) {

--- a/src/main/java/org/osiam/resources/provisioning/update/X509CertificateUpdater.java
+++ b/src/main/java/org/osiam/resources/provisioning/update/X509CertificateUpdater.java
@@ -23,9 +23,7 @@
 
 package org.osiam.resources.provisioning.update;
 
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.base.Strings;
 import org.osiam.resources.converter.X509CertificateConverter;
 import org.osiam.resources.scim.X509Certificate;
 import org.osiam.storage.entities.UserEntity;
@@ -33,7 +31,8 @@ import org.osiam.storage.entities.X509CertificateEntity;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.google.common.base.Strings;
+import java.util.List;
+import java.util.Set;
 
 /**
  * The X509CertificateUpdater provides the functionality to update the {@link X509CertificateEntity} of a UserEntity
@@ -41,19 +40,20 @@ import com.google.common.base.Strings;
 @Service
 class X509CertificateUpdater {
 
-    @Autowired
     private X509CertificateConverter x509CertificateConverter;
+
+    @Autowired
+    public X509CertificateUpdater(X509CertificateConverter x509CertificateConverter) {
+        this.x509CertificateConverter = x509CertificateConverter;
+    }
 
     /**
      * updates (adds new, delete, updates) the {@link X509CertificateEntity}'s of the given {@link UserEntity} based on
      * the given List of X509Certificate's
-     * 
-     * @param x509Certificates
-     *            list of X509Certificate's to be deleted, updated or added
-     * @param userEntity
-     *            user who needs to be updated
-     * @param attributes
-     *            all {@link X509CertificateEntity}'s will be deleted if this Set contains 'x509Certificates'
+     *
+     * @param x509Certificates list of X509Certificate's to be deleted, updated or added
+     * @param userEntity       user who needs to be updated
+     * @param attributes       all {@link X509CertificateEntity}'s will be deleted if this Set contains 'x509Certificates'
      */
     void update(List<X509Certificate> x509Certificates, UserEntity userEntity, Set<String> attributes) {
 
@@ -65,7 +65,7 @@ class X509CertificateUpdater {
             for (X509Certificate scimX509Certificate : x509Certificates) {
                 X509CertificateEntity x509CertificateEntity = x509CertificateConverter.fromScim(scimX509Certificate);
                 userEntity.removeX509Certificate(x509CertificateEntity); // we always have to remove the x509Certificate
-                                                                         // the primary attribute has changed
+                // the primary attribute has changed
                 if (Strings.isNullOrEmpty(scimX509Certificate.getOperation())
                         || !scimX509Certificate.getOperation().equalsIgnoreCase("delete")) {
 
@@ -79,14 +79,12 @@ class X509CertificateUpdater {
     /**
      * if the given newX509Certificate is set to primary the primary attribute of all existing x509Certificate's in the
      * {@link UserEntity} will be removed
-     * 
-     * @param newX509Certificate
-     *            to be checked if it is primary
-     * @param x509Certificates
-     *            all existing x509Certificate's of the {@link UserEntity}
+     *
+     * @param newX509Certificate to be checked if it is primary
+     * @param x509Certificates   all existing x509Certificate's of the {@link UserEntity}
      */
     private void ensureOnlyOnePrimaryX509CertificateExists(X509CertificateEntity newX509Certificate,
-            Set<X509CertificateEntity> x509Certificates) {
+                                                           Set<X509CertificateEntity> x509Certificates) {
         if (newX509Certificate.isPrimary()) {
             for (X509CertificateEntity exisitngX509CertificateEntity : x509Certificates) {
                 if (exisitngX509CertificateEntity.isPrimary()) {

--- a/src/main/java/org/osiam/security/authorization/AccessTokenValidationService.java
+++ b/src/main/java/org/osiam/security/authorization/AccessTokenValidationService.java
@@ -40,8 +40,12 @@ import org.springframework.stereotype.*;
 @Service
 public class AccessTokenValidationService implements ResourceServerTokenServices {
 
-    @Value("${org.osiam.auth-server.home}")
     private String authServerHome;
+
+    @Autowired
+    public AccessTokenValidationService(@Value("${org.osiam.auth-server.home}") String authServerHome) {
+        this.authServerHome = authServerHome;
+    }
 
     @Override
     public OAuth2Authentication loadAuthentication(String token) {

--- a/src/main/java/org/osiam/storage/dao/GroupDao.java
+++ b/src/main/java/org/osiam/storage/dao/GroupDao.java
@@ -34,11 +34,17 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class GroupDao implements GenericDao<GroupEntity> {
 
-    @Autowired
     private GroupFilterParser filterParser;
 
-    @Autowired
     private ResourceDao resourceDao;
+
+    @Autowired
+    public GroupDao(ResourceDao resourceDao, GroupFilterParser filterParser) {
+
+        this.resourceDao = resourceDao;
+
+        this.filterParser = filterParser;
+    }
 
     @Override
     public void create(GroupEntity group) {
@@ -57,8 +63,7 @@ public class GroupDao implements GenericDao<GroupEntity> {
     /**
      * Checks if a displayName is already taken by another group.
      *
-     * @param displayName
-     *            the displayName to check
+     * @param displayName the displayName to check
      * @return true if the displayName is taken, otherwise false
      */
     public boolean isDisplayNameAlreadyTaken(String displayName) {
@@ -68,10 +73,8 @@ public class GroupDao implements GenericDao<GroupEntity> {
     /**
      * Checks if a displayName is already taken by another group. Ignores the group with the given id.
      *
-     * @param displayName
-     *            the displayName to check
-     * @param id
-     *            the id of the group to ignore
+     * @param displayName the displayName to check
+     * @param id          the id of the group to ignore
      * @return true if the displayName is taken, otherwise false
      */
     public boolean isDisplayNameAlreadyTaken(String displayName, String id) {
@@ -81,8 +84,7 @@ public class GroupDao implements GenericDao<GroupEntity> {
     /**
      * Checks if a external id is already taken by another group or user.
      *
-     * @param externalId
-     *            the external id to check
+     * @param externalId the external id to check
      * @return true if the external id is taken, otherwise false
      */
     public boolean isExternalIdAlreadyTaken(String externalId) {
@@ -92,10 +94,8 @@ public class GroupDao implements GenericDao<GroupEntity> {
     /**
      * Checks if a external id is already taken by another group or user. Ignores the group with the given id.
      *
-     * @param externalId
-     *            the external id to check
-     * @param id
-     *            the id of the group to ignore
+     * @param externalId the external id to check
+     * @param id         the id of the group to ignore
      * @return true if the displayName is taken, otherwise false
      */
     public boolean isExternalIdAlreadyTaken(String externalId, String id) {
@@ -118,7 +118,7 @@ public class GroupDao implements GenericDao<GroupEntity> {
 
     @Override
     public SearchResult<GroupEntity> search(ParseTree filterTree, String sortBy, String sortOrder, int count,
-            int startIndex) {
+                                            int startIndex) {
         return resourceDao.search(GroupEntity.class, filterTree, count, startIndex, sortBy, sortOrder, filterParser);
     }
 

--- a/src/main/java/org/osiam/storage/dao/UserDao.java
+++ b/src/main/java/org/osiam/storage/dao/UserDao.java
@@ -34,11 +34,15 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class UserDao implements GenericDao<UserEntity> {
 
-    @Autowired
     private UserFilterParser filterParser;
 
-    @Autowired
     private ResourceDao resourceDao;
+
+    @Autowired
+    public UserDao(UserFilterParser filterParser, ResourceDao resourceDao) {
+        this.filterParser = filterParser;
+        this.resourceDao = resourceDao;
+    }
 
     @Override
     public void create(UserEntity userEntity) {
@@ -65,8 +69,7 @@ public class UserDao implements GenericDao<UserEntity> {
     /**
      * Checks if a userName is already taken by another user.
      *
-     * @param userName
-     *            the userName to check
+     * @param userName the userName to check
      * @return true if the userName is taken, otherwise false
      */
     public boolean isUserNameAlreadyTaken(String userName) {
@@ -76,10 +79,8 @@ public class UserDao implements GenericDao<UserEntity> {
     /**
      * Checks if a userName is already taken by another user. Ignores the user with the given id.
      *
-     * @param userName
-     *            the userName to check
-     * @param id
-     *            the id of the user to ignore
+     * @param userName the userName to check
+     * @param id       the id of the user to ignore
      * @return true if the userName is taken, otherwise false
      */
     public boolean isUserNameAlreadyTaken(String userName, String id) {
@@ -89,8 +90,7 @@ public class UserDao implements GenericDao<UserEntity> {
     /**
      * Checks if a externalId is already taken by another user.
      *
-     * @param externalId
-     *            the userName to check
+     * @param externalId the userName to check
      * @return true if the externalId is taken, otherwise false
      */
     public boolean isExternalIdAlreadyTaken(String externalId) {
@@ -100,10 +100,8 @@ public class UserDao implements GenericDao<UserEntity> {
     /**
      * Checks if a externalId is already taken by another user. Ignores the user with the given id.
      *
-     * @param externalId
-     *            the externalId to check
-     * @param id
-     *            the id of the user to ignore
+     * @param externalId the externalId to check
+     * @param id         the id of the user to ignore
      * @return true if the externalId is taken, otherwise false
      */
     public boolean isExternalIdAlreadyTaken(String externalId, String id) {
@@ -126,7 +124,7 @@ public class UserDao implements GenericDao<UserEntity> {
 
     @Override
     public SearchResult<UserEntity> search(ParseTree filterTree, String sortBy, String sortOrder, int count,
-            int startIndex) {
+                                           int startIndex) {
         return resourceDao.search(UserEntity.class, filterTree, count, startIndex, sortBy, sortOrder, filterParser);
     }
 

--- a/src/main/java/org/osiam/storage/entities/AddressEntity.java
+++ b/src/main/java/org/osiam/storage/entities/AddressEntity.java
@@ -47,7 +47,7 @@ public class AddressEntity extends BaseMultiValuedAttributeEntity {
      * <p>
      * The type of this Address.
      * </p>
-     * 
+     *
      * <p>
      * Custom type mapping is provided by {@link org.osiam.storage.entities.jpa_converters.AddressTypeConverter}.
      * </p>
@@ -206,12 +206,9 @@ public class AddressEntity extends BaseMultiValuedAttributeEntity {
 
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder();
-        builder.append("AddressEntity [type=").append(type).append(", formatted=").append(formatted)
-                .append(", streetAddress=").append(streetAddress).append(", locality=").append(locality)
-                .append(", region=").append(region).append(", postalCode=").append(postalCode).append(", country=")
-                .append(country).append(", primary=").append(isPrimary()).append("]");
-        return builder.toString();
+        return "AddressEntity [type=" + type + ", formatted=" + formatted + ", streetAddress=" + streetAddress
+                + ", locality=" + locality + ", region=" + region + ", postalCode=" + postalCode + ", country="
+                + country + ", primary=" + isPrimary() + "]";
     }
 
 }

--- a/src/main/java/org/osiam/storage/entities/EmailEntity.java
+++ b/src/main/java/org/osiam/storage/entities/EmailEntity.java
@@ -94,10 +94,7 @@ public class EmailEntity extends BaseMultiValuedAttributeEntityWithValue {
 
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder();
-        builder.append("EmailEntity [type=").append(type).append(", getValue()=").append(getValue())
-                .append(", isPrimary()=").append(isPrimary()).append("]");
-        return builder.toString();
+        return "EmailEntity [type=" + type + ", getValue()=" + getValue() + ", isPrimary()=" + isPrimary() + "]";
     }
 
 }

--- a/src/main/java/org/osiam/storage/entities/EntitlementEntity.java
+++ b/src/main/java/org/osiam/storage/entities/EntitlementEntity.java
@@ -46,7 +46,7 @@ public class EntitlementEntity extends BaseMultiValuedAttributeEntityWithValue {
      * <p>
      * The type of this Entitlement.
      * </p>
-     * 
+     *
      * <p>
      * Custom type mapping is provided by {@link org.osiam.storage.entities.jpa_converters.EntitlementTypeConverter}.
      * </p>
@@ -94,10 +94,7 @@ public class EntitlementEntity extends BaseMultiValuedAttributeEntityWithValue {
 
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder();
-        builder.append("EntitlementsEntity [type=").append(type).append(", getValue()=").append(getValue())
-                .append(", isPrimary()=").append(isPrimary()).append("]");
-        return builder.toString();
+        return "EntitlementsEntity [type=" + type + ", getValue()=" + getValue() + ", isPrimary()=" + isPrimary() + "]";
     }
 
 }

--- a/src/main/java/org/osiam/storage/entities/ExtensionEntity.java
+++ b/src/main/java/org/osiam/storage/entities/ExtensionEntity.java
@@ -140,9 +140,7 @@ public class ExtensionEntity {
 
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder();
-        builder.append("ExtensionEntity [urn=").append(urn).append("]");
-        return builder.toString();
+        return "ExtensionEntity [urn=" + urn + "]";
     }
 
 }

--- a/src/main/java/org/osiam/storage/entities/ExtensionFieldEntity.java
+++ b/src/main/java/org/osiam/storage/entities/ExtensionFieldEntity.java
@@ -184,10 +184,7 @@ public class ExtensionFieldEntity {
 
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder();
-        builder.append("ExtensionFieldEntity [name=").append(name).append(", type=").append(type)
-                .append(", isRequired=").append(required).append("]");
-        return builder.toString();
+        return "ExtensionFieldEntity [name=" + name + ", type=" + type + ", isRequired=" + required + "]";
     }
 
     private static class ConstraintAndType {

--- a/src/main/java/org/osiam/storage/entities/ExtensionFieldValueEntity.java
+++ b/src/main/java/org/osiam/storage/entities/ExtensionFieldValueEntity.java
@@ -125,10 +125,7 @@ public class ExtensionFieldValueEntity {
 
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder();
-        builder.append("ExtensionFieldValueEntity [extensionField=").append(extensionField).append(", value=")
-                .append(value).append("]");
-        return builder.toString();
+        return "ExtensionFieldValueEntity [extensionField=" + extensionField + ", value=" + value + "]";
     }
 
 }

--- a/src/main/java/org/osiam/storage/entities/GroupEntity.java
+++ b/src/main/java/org/osiam/storage/entities/GroupEntity.java
@@ -98,10 +98,7 @@ public class GroupEntity extends ResourceEntity {
 
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder();
-        builder.append("GroupEntity [displayName=").append(displayName).append(", getId()=").append(getId())
-                .append("]");
-        return builder.toString();
+        return "GroupEntity [displayName=" + displayName + ", getId()=" + getId() + "]";
     }
 
     @Override

--- a/src/main/java/org/osiam/storage/entities/MetaEntity.java
+++ b/src/main/java/org/osiam/storage/entities/MetaEntity.java
@@ -188,11 +188,8 @@ public class MetaEntity {
 
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder();
-        builder.append("MetaEntity [created=").append(created).append(", lastModified=").append(lastModified)
-                .append(", location=").append(location).append(", version=").append(version).append(", resourceType=")
-                .append(resourceType).append("]");
-        return builder.toString();
+        return "MetaEntity [created=" + created + ", lastModified=" + lastModified + ", location=" + location
+                + ", version=" + version + ", resourceType=" + resourceType + "]";
     }
 
 }

--- a/src/main/java/org/osiam/storage/entities/NameEntity.java
+++ b/src/main/java/org/osiam/storage/entities/NameEntity.java
@@ -193,12 +193,9 @@ public class NameEntity {
 
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder();
-        builder.append("NameEntity [formatted=").append(formatted).append(", familyName=").append(familyName)
-                .append(", givenName=").append(givenName).append(", middleName=").append(middleName)
-                .append(", honorificPrefix=").append(honorificPrefix).append(", honorificSuffix=")
-                .append(honorificSuffix).append("]");
-        return builder.toString();
+        return "NameEntity [formatted=" + formatted + ", familyName=" + familyName + ", givenName=" + givenName
+                + ", middleName=" + middleName + ", honorificPrefix=" + honorificPrefix + ", honorificSuffix="
+                + honorificSuffix + "]";
     }
 
 }

--- a/src/main/java/org/osiam/storage/entities/PhotoEntity.java
+++ b/src/main/java/org/osiam/storage/entities/PhotoEntity.java
@@ -46,7 +46,7 @@ public class PhotoEntity extends BaseMultiValuedAttributeEntityWithValue {
      * <p>
      * The type of this Photo.
      * </p>
-     * 
+     *
      * <p>
      * Custom type mapping is provided by {@link org.osiam.storage.entities.jpa_converters.PhotoTypeConverter}.
      * </p>
@@ -99,9 +99,7 @@ public class PhotoEntity extends BaseMultiValuedAttributeEntityWithValue {
 
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder();
-        builder.append("PhotoEntity [type=").append(type).append(", getValue()=").append(getValue()).append("]");
-        return builder.toString();
+        return "PhotoEntity [type=" + type + ", getValue()=" + getValue() + "]";
     }
 
 }

--- a/src/main/java/org/osiam/storage/entities/UserEntity.java
+++ b/src/main/java/org/osiam/storage/entities/UserEntity.java
@@ -23,23 +23,14 @@
 
 package org.osiam.storage.entities;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.JoinColumn;
-import javax.persistence.Lob;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
-
+import com.google.common.collect.ImmutableSet;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Type;
 import org.osiam.resources.scim.MemberRef;
 
-import com.google.common.collect.ImmutableSet;
+import javax.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * User Entity
@@ -137,8 +128,7 @@ public class UserEntity extends ResourceEntity {
     }
 
     /**
-     * @param name
-     *            the name entity
+     * @param name the name entity
      */
     public void setName(NameEntity name) {
         this.name = name;
@@ -152,8 +142,7 @@ public class UserEntity extends ResourceEntity {
     }
 
     /**
-     * @param nickName
-     *            the nick name
+     * @param nickName the nick name
      */
     public void setNickName(String nickName) {
         this.nickName = nickName;
@@ -167,8 +156,7 @@ public class UserEntity extends ResourceEntity {
     }
 
     /**
-     * @param profileUrl
-     *            the profile url
+     * @param profileUrl the profile url
      */
     public void setProfileUrl(String profileUrl) {
         this.profileUrl = profileUrl;
@@ -182,8 +170,7 @@ public class UserEntity extends ResourceEntity {
     }
 
     /**
-     * @param title
-     *            the title
+     * @param title the title
      */
     public void setTitle(String title) {
         this.title = title;
@@ -197,8 +184,7 @@ public class UserEntity extends ResourceEntity {
     }
 
     /**
-     * @param userType
-     *            the user type
+     * @param userType the user type
      */
     public void setUserType(String userType) {
         this.userType = userType;
@@ -212,8 +198,7 @@ public class UserEntity extends ResourceEntity {
     }
 
     /**
-     * @param preferredLanguage
-     *            the preferred languages
+     * @param preferredLanguage the preferred languages
      */
     public void setPreferredLanguage(String preferredLanguage) {
         this.preferredLanguage = preferredLanguage;
@@ -227,8 +212,7 @@ public class UserEntity extends ResourceEntity {
     }
 
     /**
-     * @param locale
-     *            the locale
+     * @param locale the locale
      */
     public void setLocale(String locale) {
         this.locale = locale;
@@ -242,8 +226,7 @@ public class UserEntity extends ResourceEntity {
     }
 
     /**
-     * @param timezone
-     *            the timezone
+     * @param timezone the timezone
      */
     public void setTimezone(String timezone) {
         this.timezone = timezone;
@@ -257,8 +240,7 @@ public class UserEntity extends ResourceEntity {
     }
 
     /**
-     * @param active
-     *            the active status
+     * @param active the active status
      */
     public void setActive(Boolean active) {
         this.active = active;
@@ -272,8 +254,7 @@ public class UserEntity extends ResourceEntity {
     }
 
     /**
-     * @param password
-     *            the password
+     * @param password the password
      */
     public void setPassword(String password) {
         this.password = password;
@@ -293,8 +274,7 @@ public class UserEntity extends ResourceEntity {
     }
 
     /**
-     * @param userName
-     *            the user name
+     * @param userName the user name
      */
     public void setUserName(String userName) {
         this.userName = userName;
@@ -312,8 +292,7 @@ public class UserEntity extends ResourceEntity {
     /**
      * Adds a new email to this user
      *
-     * @param email
-     *            the email to add
+     * @param email the email to add
      */
     public void addEmail(EmailEntity email) {
         emails.add(email);
@@ -322,8 +301,7 @@ public class UserEntity extends ResourceEntity {
     /**
      * Removes the given email from this user
      *
-     * @param email
-     *            the email to remove
+     * @param email the email to remove
      */
     public void removeEmail(EmailEntity email) {
         emails.remove(email);
@@ -346,8 +324,7 @@ public class UserEntity extends ResourceEntity {
     /**
      * Adds a new extensionFieldValue to this user
      *
-     * @param extensionFieldValue
-     *            the extensionFieldValue to add
+     * @param extensionFieldValue the extensionFieldValue to add
      */
     public void addExtensionFieldValue(ExtensionFieldValueEntity extensionFieldValue) {
         extensionFieldValues.add(extensionFieldValue);
@@ -356,8 +333,7 @@ public class UserEntity extends ResourceEntity {
     /**
      * Removes the given extensionFieldValue from this user
      *
-     * @param extensionFieldValue
-     *            the extensionFieldValue to remove
+     * @param extensionFieldValue the extensionFieldValue to remove
      */
     public void removeExtensionFieldValue(ExtensionFieldValueEntity extensionFieldValue) {
         extensionFieldValues.remove(extensionFieldValue);
@@ -379,8 +355,7 @@ public class UserEntity extends ResourceEntity {
      * Adds or updates an extension field value for this User. When updating, the old value of the extension field is
      * removed from this user and the new one will be added.
      *
-     * @param extensionValue
-     *            The extension field value to add or update
+     * @param extensionValue The extension field value to add or update
      */
     public void addOrUpdateExtensionValue(ExtensionFieldValueEntity extensionValue) {
         if (extensionValue == null) {
@@ -404,8 +379,7 @@ public class UserEntity extends ResourceEntity {
     /**
      * Adds a new phoneNumber to this user
      *
-     * @param phoneNumber
-     *            the phoneNumnber to add
+     * @param phoneNumber the phoneNumnber to add
      */
     public void addPhoneNumber(PhoneNumberEntity phoneNumber) {
         phoneNumbers.add(phoneNumber);
@@ -414,8 +388,7 @@ public class UserEntity extends ResourceEntity {
     /**
      * Removes the given phoneNumber from this user
      *
-     * @param phoneNumber
-     *            the phoneNumber to remove
+     * @param phoneNumber the phoneNumber to remove
      */
     public void removePhoneNumber(PhoneNumberEntity phoneNumber) {
         phoneNumbers.remove(phoneNumber);
@@ -438,8 +411,7 @@ public class UserEntity extends ResourceEntity {
     /**
      * Adds a new im to this user
      *
-     * @param im
-     *            the im to add
+     * @param im the im to add
      */
     public void addIm(ImEntity im) {
         ims.add(im);
@@ -448,8 +420,7 @@ public class UserEntity extends ResourceEntity {
     /**
      * Removes the given im from this user
      *
-     * @param im
-     *            the im to remove
+     * @param im the im to remove
      */
     public void removeIm(ImEntity im) {
         ims.remove(im);
@@ -472,8 +443,7 @@ public class UserEntity extends ResourceEntity {
     /**
      * Adds a new photo to this user
      *
-     * @param photo
-     *            the photo to add
+     * @param photo the photo to add
      */
     public void addPhoto(PhotoEntity photo) {
         photos.add(photo);
@@ -482,8 +452,7 @@ public class UserEntity extends ResourceEntity {
     /**
      * Removes the given photo from this user
      *
-     * @param photo
-     *            the photo to remove
+     * @param photo the photo to remove
      */
     public void removePhoto(PhotoEntity photo) {
         photos.remove(photo);
@@ -506,8 +475,7 @@ public class UserEntity extends ResourceEntity {
     /**
      * Adds a new address to this user
      *
-     * @param address
-     *            the address to add
+     * @param address the address to add
      */
     public void addAddress(AddressEntity address) {
         addresses.add(address);
@@ -516,8 +484,7 @@ public class UserEntity extends ResourceEntity {
     /**
      * Removes the given address from this user
      *
-     * @param address
-     *            the address to remove
+     * @param address the address to remove
      */
     public void removeAddress(AddressEntity address) {
         addresses.remove(address);
@@ -540,8 +507,7 @@ public class UserEntity extends ResourceEntity {
     /**
      * Adds a new entitlement to this user
      *
-     * @param entitlement
-     *            the entitlement to add
+     * @param entitlement the entitlement to add
      */
     public void addEntitlement(EntitlementEntity entitlement) {
         entitlements.add(entitlement);
@@ -550,8 +516,7 @@ public class UserEntity extends ResourceEntity {
     /**
      * Removes the given entitlement from this user
      *
-     * @param entitlement
-     *            the entitlement to remove
+     * @param entitlement the entitlement to remove
      */
     public void removeEntitlement(EntitlementEntity entitlement) {
         entitlements.remove(entitlement);
@@ -574,8 +539,7 @@ public class UserEntity extends ResourceEntity {
     /**
      * Adds a new role to this user
      *
-     * @param role
-     *            the role to add
+     * @param role the role to add
      */
     public void addRole(RoleEntity role) {
         roles.add(role);
@@ -584,8 +548,7 @@ public class UserEntity extends ResourceEntity {
     /**
      * Removes the given role from this user
      *
-     * @param role
-     *            the role to remove
+     * @param role the role to remove
      */
     public void removeRole(RoleEntity role) {
         roles.remove(role);
@@ -608,8 +571,7 @@ public class UserEntity extends ResourceEntity {
     /**
      * Adds a new x509Certificate to this user
      *
-     * @param x509Certificate
-     *            the x509Certificate to add
+     * @param x509Certificate the x509Certificate to add
      */
     public void addX509Certificate(X509CertificateEntity x509Certificate) {
         x509Certificates.add(x509Certificate);
@@ -618,8 +580,7 @@ public class UserEntity extends ResourceEntity {
     /**
      * Removes the given x509Certificate from this user
      *
-     * @param x509Certificate
-     *            the x509Certificate to remove
+     * @param x509Certificate the x509Certificate to remove
      */
     public void removeX509Certificate(X509CertificateEntity x509Certificate) {
         x509Certificates.remove(x509Certificate);
@@ -634,9 +595,7 @@ public class UserEntity extends ResourceEntity {
 
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder();
-        builder.append("UserEntity [userName=").append(userName).append(", getId()=").append(getId()).append("]");
-        return builder.toString();
+        return "UserEntity [userName=" + userName + ", getId()=" + getId() + "]";
     }
 
     @Override

--- a/src/main/java/org/osiam/storage/helper/NumberPadder.java
+++ b/src/main/java/org/osiam/storage/helper/NumberPadder.java
@@ -23,14 +23,11 @@
 
 package org.osiam.storage.helper;
 
+import com.google.common.base.Strings;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
-import org.springframework.stereotype.Service;
-
-import com.google.common.base.Strings;
-
-@Service
 public class NumberPadder {
 
     private static final String OFFSET = "100000000000000000000";
@@ -40,8 +37,7 @@ public class NumberPadder {
     /**
      * Adds an offset and padding to a number
      *
-     * @param value
-     *            the number as {@link String}
+     * @param value the number as {@link String}
      * @return the padded string with the added offset.
      */
     public String pad(String value) {
@@ -69,8 +65,7 @@ public class NumberPadder {
     /**
      * Removes the offset and padding from a number
      *
-     * @param value
-     *            the padded number as {@link String}
+     * @param value the padded number as {@link String}
      * @return the number decreased by offset and leading '0's removed
      */
     public String unpad(String value) {

--- a/src/main/java/org/osiam/storage/query/ExtensionQueryField.java
+++ b/src/main/java/org/osiam/storage/query/ExtensionQueryField.java
@@ -23,22 +23,12 @@
 
 package org.osiam.storage.query;
 
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.Join;
-import javax.persistence.criteria.JoinType;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
-import javax.persistence.criteria.SetJoin;
-import javax.persistence.metamodel.SetAttribute;
-
 import org.osiam.resources.scim.ExtensionFieldType;
-import org.osiam.storage.entities.ExtensionFieldEntity;
-import org.osiam.storage.entities.ExtensionFieldEntity_;
-import org.osiam.storage.entities.ExtensionFieldValueEntity;
-import org.osiam.storage.entities.ExtensionFieldValueEntity_;
-import org.osiam.storage.entities.UserEntity;
-import org.osiam.storage.entities.UserEntity_;
+import org.osiam.storage.entities.*;
 import org.osiam.storage.helper.NumberPadder;
+
+import javax.persistence.criteria.*;
+import javax.persistence.metamodel.SetAttribute;
 
 public class ExtensionQueryField {
 
@@ -46,14 +36,14 @@ public class ExtensionQueryField {
     private final ExtensionFieldEntity field;
     private final NumberPadder numberPadder;
 
-    public ExtensionQueryField(String urn, ExtensionFieldEntity field, NumberPadder numberPadder) {
+    public ExtensionQueryField(String urn, ExtensionFieldEntity field) {
         this.urn = urn;
         this.field = field;
-        this.numberPadder = numberPadder;
+        this.numberPadder = new NumberPadder();
     }
 
     public Predicate addFilter(Root<UserEntity> root, FilterConstraint constraint,
-            String value, CriteriaBuilder cb) {
+                               String value, CriteriaBuilder cb) {
 
         if (constraint != FilterConstraint.PRESENT && (field.getType() == ExtensionFieldType.INTEGER ||
                 field.getType() == ExtensionFieldType.DECIMAL)) {
@@ -87,7 +77,7 @@ public class ExtensionQueryField {
 
     @SuppressWarnings("unchecked")
     protected SetJoin<UserEntity, ExtensionFieldValueEntity> createOrGetJoin(String alias, Root<UserEntity> root,
-            SetAttribute<UserEntity, ExtensionFieldValueEntity> attribute) {
+                                                                             SetAttribute<UserEntity, ExtensionFieldValueEntity> attribute) {
 
         for (Join<UserEntity, ?> currentJoin : root.getJoins()) {
             if (currentJoin.getAlias() == null) {

--- a/src/main/java/org/osiam/storage/query/QueryFilterParser.java
+++ b/src/main/java/org/osiam/storage/query/QueryFilterParser.java
@@ -32,7 +32,6 @@ import org.springframework.stereotype.Service;
 
 import com.google.common.base.Strings;
 
-@Service
 public class QueryFilterParser {
 
     public ParseTree getParseTree(String filter) {

--- a/src/main/java/org/osiam/storage/query/UserFilterParser.java
+++ b/src/main/java/org/osiam/storage/query/UserFilterParser.java
@@ -23,26 +23,26 @@
 
 package org.osiam.storage.query;
 
-import java.util.Locale;
-
 import org.osiam.storage.dao.ExtensionDao;
 import org.osiam.storage.entities.UserEntity;
-import org.osiam.storage.helper.NumberPadder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.Locale;
 
 @Service
 public class UserFilterParser extends FilterParser<UserEntity> {
 
-    @Autowired
     private ExtensionDao extensionDao;
 
     @Autowired
-    private NumberPadder numberPadder;
+    public UserFilterParser(ExtensionDao extensionDao) {
+        this.extensionDao = extensionDao;
+    }
 
     @Override
     protected FilterChain<UserEntity> createFilterChain(ScimExpression filter) {
-        return new UserSimpleFilterChain(entityManager.getCriteriaBuilder(), extensionDao, filter, numberPadder);
+        return new UserSimpleFilterChain(entityManager.getCriteriaBuilder(), extensionDao, filter);
     }
 
     @Override

--- a/src/main/java/org/osiam/storage/query/UserSimpleFilterChain.java
+++ b/src/main/java/org/osiam/storage/query/UserSimpleFilterChain.java
@@ -23,18 +23,16 @@
 
 package org.osiam.storage.query;
 
-import java.util.Locale;
-
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
-
 import org.osiam.resources.exception.OsiamException;
 import org.osiam.storage.dao.ExtensionDao;
 import org.osiam.storage.entities.ExtensionEntity;
 import org.osiam.storage.entities.ExtensionFieldEntity;
 import org.osiam.storage.entities.UserEntity;
-import org.osiam.storage.helper.NumberPadder;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import java.util.Locale;
 
 public class UserSimpleFilterChain implements FilterChain<UserEntity> {
 
@@ -43,15 +41,12 @@ public class UserSimpleFilterChain implements FilterChain<UserEntity> {
     private final QueryField<UserEntity> userFilterField;
     private final ExtensionDao extensionDao;
     private final CriteriaBuilder criteriaBuilder;
-    private final NumberPadder numberPadder;
     private ExtensionQueryField extensionFilterField;
 
     public UserSimpleFilterChain(CriteriaBuilder criteriaBuilder, ExtensionDao extensionDao,
-            ScimExpression scimExpression,
-            NumberPadder numberPadder) {
+                                 ScimExpression scimExpression) {
         this.criteriaBuilder = criteriaBuilder;
         this.extensionDao = extensionDao;
-        this.numberPadder = numberPadder;
         this.scimExpression = scimExpression;
 
         String field = scimExpression.getField();
@@ -82,7 +77,7 @@ public class UserSimpleFilterChain implements FilterChain<UserEntity> {
             return null;
         }
         final ExtensionFieldEntity fieldEntity = extension.getFieldForName(fieldName, true);
-        return new ExtensionQueryField(urn, fieldEntity, numberPadder);
+        return new ExtensionQueryField(urn, fieldEntity);
     }
 
     @Override

--- a/src/test/groovy/org/osiam/resources/converter/ExtensionConverterSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/converter/ExtensionConverterSpec.groovy
@@ -23,6 +23,7 @@
 
 package org.osiam.resources.converter
 
+import com.sun.xml.internal.bind.v2.schemagen.xmlschema.ExtensionType
 import org.joda.time.format.ISODateTimeFormat
 import org.osiam.resources.scim.Extension
 import org.osiam.resources.scim.ExtensionFieldType
@@ -39,9 +40,8 @@ class ExtensionConverterSpec extends Specification {
     private static String URN2 = "urn:org.osiam.extensions:Test02:1.0"
 
     private ExtensionDao extensionDao = Mock()
-    private NumberPadder numberPadder = Mock()
 
-    private ExtensionConverter converter = new ExtensionConverter(extensionDao: extensionDao, numberPadder: numberPadder)
+    private ExtensionConverter converter = new ExtensionConverter(extensionDao)
 
     Map fixtures = [(URN1): [
             [fieldname: 'gender', valueAsString: 'male', value: 'male', type: ExtensionFieldType.STRING],
@@ -64,8 +64,6 @@ class ExtensionConverterSpec extends Specification {
         Set<Extension> extensions = converter.toScim(extensionFieldValueEntitySet)
 
         then:
-        1 * numberPadder.unpad('1.78') >> '1.78'
-        1 * numberPadder.unpad('2') >> '2'
         extensions == scimExtensionSet
     }
 
@@ -81,8 +79,6 @@ class ExtensionConverterSpec extends Specification {
         then:
         1 * extensionDao.getExtensionByUrn(URN1) >> extensionMap[URN1]
         1 * extensionDao.getExtensionByUrn(URN2) >> extensionMap[URN2]
-        1 * numberPadder.pad('1.78') >> '1.78'
-        1 * numberPadder.pad('2') >> '2'
         extensions == extensionFieldValueEntitySet
     }
 
@@ -167,6 +163,10 @@ class ExtensionConverterSpec extends Specification {
         ExtensionFieldEntity fieldEntity = new ExtensionFieldEntity()
         fieldEntity.setName(name)
         fieldEntity.setType(type)
+        if (type == ExtensionFieldType.INTEGER || type == ExtensionFieldType.DECIMAL ){
+            def numberPadder = new NumberPadder();
+            value = numberPadder.pad(value)
+        }
 
         ExtensionFieldValueEntity valueEntity = new ExtensionFieldValueEntity()
         valueEntity.setValue(value)

--- a/src/test/groovy/org/osiam/resources/provisioning/SCIMGroupProvisioningBeanSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/provisioning/SCIMGroupProvisioningBeanSpec.groovy
@@ -32,7 +32,6 @@ import org.osiam.resources.scim.MemberRef
 import org.osiam.storage.dao.GroupDao
 import org.osiam.storage.dao.SearchResult
 import org.osiam.storage.entities.GroupEntity
-import org.osiam.storage.query.QueryFilterParser
 import spock.lang.Specification
 
 import javax.persistence.NoResultException
@@ -42,10 +41,9 @@ class SCIMGroupProvisioningBeanSpec extends Specification {
     GroupDao groupDao = Mock()
     GroupConverter groupConverter = Mock()
     GroupUpdater groupUpdater = Mock()
-    QueryFilterParser queryFilterParser = new QueryFilterParser()
 
     SCIMGroupProvisioning scimGroupProvisioning = new SCIMGroupProvisioning(groupDao: groupDao, groupConverter: groupConverter,
-            groupUpdater: groupUpdater, queryFilterParser: queryFilterParser)
+            groupUpdater: groupUpdater)
 
     Group group = Mock()
     GroupEntity groupEntity = Mock()

--- a/src/test/groovy/org/osiam/resources/provisioning/SCIMUserProvisioningBeanSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/provisioning/SCIMUserProvisioningBeanSpec.groovy
@@ -30,7 +30,6 @@ import org.osiam.storage.dao.SearchResult
 import org.osiam.storage.dao.UserDao
 import org.osiam.storage.entities.MetaEntity
 import org.osiam.storage.entities.UserEntity
-import org.osiam.storage.query.QueryFilterParser
 import org.springframework.security.authentication.encoding.PasswordEncoder
 import spock.lang.Specification
 
@@ -39,10 +38,9 @@ class SCIMUserProvisioningBeanSpec extends Specification {
     PasswordEncoder passwordEncoder = Mock()
     UserDao userDao = Mock()
     UserConverter userConverter = Mock()
-    QueryFilterParser queryFilterParser = new QueryFilterParser()
 
     SCIMUserProvisioning scimUserProvisioningBean = new SCIMUserProvisioning(userDao: userDao,
-            userConverter: userConverter, passwordEncoder: passwordEncoder, queryFilterParser: queryFilterParser)
+            userConverter: userConverter, passwordEncoder: passwordEncoder)
 
     def 'should be possible to get a user by his id'() {
         given:

--- a/src/test/groovy/org/osiam/resources/provisioning/update/AddressUpdaterSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/provisioning/update/AddressUpdaterSpec.groovy
@@ -35,9 +35,8 @@ class AddressUpdaterSpec extends Specification {
     static IRRELEVANT_02 = 'irrelevant02'
 
     UserEntity userEntity = Mock()
-    AddressEntity addressEntity = Mock()
     AddressConverter addressConverter = Mock()
-    AddressUpdater addressUpdater = new AddressUpdater(addressConverter: addressConverter)
+    AddressUpdater addressUpdater = new AddressUpdater(addressConverter)
 
     def 'removing all addresses is possible'() {
         when:

--- a/src/test/groovy/org/osiam/resources/provisioning/update/EmailUpdaterSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/provisioning/update/EmailUpdaterSpec.groovy
@@ -35,9 +35,8 @@ class EmailUpdaterSpec extends Specification {
     static IRRELEVANT_02 = 'irrelevant02@tarent.de'
 
     UserEntity userEntity = Mock()
-    EmailEntity emailEntity = Mock()
     EmailConverter emailConverter = Mock()
-    EmailUpdater emailUpdater = new EmailUpdater(emailConverter: emailConverter)
+    EmailUpdater emailUpdater = new EmailUpdater(emailConverter)
 
     def 'removing all emails is possible'() {
         when:

--- a/src/test/groovy/org/osiam/resources/provisioning/update/EntitlementUpdaterSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/provisioning/update/EntitlementUpdaterSpec.groovy
@@ -36,9 +36,8 @@ class EntitlementUpdaterSpec extends Specification {
     static IRRELEVANT_02 = 'irrelevant02'
 
     UserEntity userEntity = Mock()
-    EntitlementEntity entitlementEntity = Mock()
     EntitlementConverter entitlementConverter = Mock()
-    EntitlementsUpdater entitlementUpdater = new EntitlementsUpdater(entitlementConverter: entitlementConverter)
+    EntitlementsUpdater entitlementUpdater = new EntitlementsUpdater(entitlementConverter)
 
     def 'removing all entitlements is possible'() {
         when:

--- a/src/test/groovy/org/osiam/resources/provisioning/update/ExtensionUpdaterSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/provisioning/update/ExtensionUpdaterSpec.groovy
@@ -42,13 +42,10 @@ class ExtensionUpdaterSpec extends Specification {
     static String URN = 'extension'
 
     static IRRELEVANT = 'irrelevant'
-    static IRRELEVANT_02 = 'irrelevant02'
 
     UserEntity userEntity = Mock()
-    ExtensionEntity extensionEntity = Mock()
-    ExtensionConverter extensionConverter = Mock()
     ExtensionDao extensionDao = Mock()
-    ExtensionUpdater extensionUpdater = new ExtensionUpdater(extensionDao: extensionDao)
+    ExtensionUpdater extensionUpdater = new ExtensionUpdater(extensionDao)
 
     def 'removing an extension is possible'() {
         when:

--- a/src/test/groovy/org/osiam/resources/provisioning/update/GroupUpdaterSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/provisioning/update/GroupUpdaterSpec.groovy
@@ -41,7 +41,7 @@ class GroupUpdaterSpec extends Specification {
     ResourceUpdater resourceUpdater = Mock()
     ResourceDao resourceDao = Mock()
     GroupDao groupDao = Mock()
-    GroupUpdater groupUpdater = new GroupUpdater(resourceUpdater: resourceUpdater, resourceDao: resourceDao, groupDao: groupDao)
+    GroupUpdater groupUpdater = new GroupUpdater(groupDao, resourceUpdater, resourceDao)
 
     Group group
     GroupEntity groupEntity = Mock()

--- a/src/test/groovy/org/osiam/resources/provisioning/update/ImUpdaterSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/provisioning/update/ImUpdaterSpec.groovy
@@ -36,9 +36,8 @@ class ImUpdaterSpec extends Specification {
     static IRRELEVANT_02 = 'irrelevant02'
 
     UserEntity userEntity = Mock()
-    ImEntity imEntity = Mock()
     ImConverter imConverter = Mock()
-    ImUpdater imUpdater = new ImUpdater(imConverter: imConverter)
+    ImUpdater imUpdater = new ImUpdater(imConverter)
 
     def 'removing all ims is possible'() {
         when:

--- a/src/test/groovy/org/osiam/resources/provisioning/update/PhoneNumbersUpdaterSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/provisioning/update/PhoneNumbersUpdaterSpec.groovy
@@ -36,9 +36,8 @@ class PhoneNumbersUpdaterSpec extends Specification {
     static IRRELEVANT_02 = 'irrelevant02'
 
     UserEntity userEntity = Mock()
-    PhoneNumberEntity phoneNumberEntity = Mock()
     PhoneNumberConverter phoneNumberConverter = Mock()
-    PhoneNumberUpdater phoneNumberUpdater = new PhoneNumberUpdater(phoneNumberConverter: phoneNumberConverter)
+    PhoneNumberUpdater phoneNumberUpdater = new PhoneNumberUpdater(phoneNumberConverter)
 
     def 'removing all phoneNumbers is possible'() {
         when:

--- a/src/test/groovy/org/osiam/resources/provisioning/update/PhotoUpdaterSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/provisioning/update/PhotoUpdaterSpec.groovy
@@ -35,9 +35,8 @@ class PhotoUpdaterSpec extends Specification {
     static IRRELEVANT_02 = 'x.GIF'
 
     UserEntity userEntity = Mock()
-    PhotoEntity photoEntity = Mock()
     PhotoConverter photoConverter = Mock()
-    PhotoUpdater photoUpdater = new PhotoUpdater(photoConverter: photoConverter)
+    PhotoUpdater photoUpdater = new PhotoUpdater(photoConverter)
 
     def 'removing all photos is possible'() {
         when:

--- a/src/test/groovy/org/osiam/resources/provisioning/update/ResourceUpdaterSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/provisioning/update/ResourceUpdaterSpec.groovy
@@ -35,7 +35,7 @@ class ResourceUpdaterSpec extends Specification {
     static String IRRELEVANT = 'irrelevant'
 
     ResourceDao resourceDao = Mock()
-    ResourceUpdater resourceUpdater = new ResourceUpdater(resourceDao: resourceDao)
+    ResourceUpdater resourceUpdater = new ResourceUpdater(resourceDao)
 
     Meta metaWithAttributesToDelete = new Meta(attributes: ['externalId'] as Set)
     // resources are abstract so we use groups here with no loss of generality

--- a/src/test/groovy/org/osiam/resources/provisioning/update/RoleUpdaterSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/provisioning/update/RoleUpdaterSpec.groovy
@@ -36,9 +36,8 @@ class RoleUpdaterSpec extends Specification {
     static IRRELEVANT_02 = 'irrelevant02'
 
     UserEntity userEntity = Mock()
-    RoleEntity roleEntity = Mock()
     RoleConverter roleConverter = Mock()
-    RoleUpdater roleUpdater = new RoleUpdater(roleConverter: roleConverter)
+    RoleUpdater roleUpdater = new RoleUpdater(roleConverter)
 
     def 'removing all roles is possible'() {
         when:

--- a/src/test/groovy/org/osiam/resources/provisioning/update/X509CertificateUpdaterSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/provisioning/update/X509CertificateUpdaterSpec.groovy
@@ -36,9 +36,8 @@ class X509CertificateUpdaterSpec extends Specification {
     static IRRELEVANT_02 = 'irrelevant02'
 
     UserEntity userEntity = Mock()
-    X509CertificateEntity x509CertificateEntity = Mock()
     X509CertificateConverter x509CertificateConverter = Mock()
-    X509CertificateUpdater x509CertificateUpdater = new X509CertificateUpdater(x509CertificateConverter: x509CertificateConverter)
+    X509CertificateUpdater x509CertificateUpdater = new X509CertificateUpdater(x509CertificateConverter)
 
     def 'removing all x509Certificate is possible'() {
         when:

--- a/src/test/groovy/org/osiam/storage/dao/GroupDaoSpec.groovy
+++ b/src/test/groovy/org/osiam/storage/dao/GroupDaoSpec.groovy
@@ -24,6 +24,7 @@
 package org.osiam.storage.dao
 
 import org.osiam.storage.entities.GroupEntity
+import org.osiam.storage.query.GroupFilterParser
 import spock.lang.Specification
 
 class GroupDaoSpec extends Specification {
@@ -31,7 +32,8 @@ class GroupDaoSpec extends Specification {
     static def IRRELEVANT = 'irrelevant'
 
     ResourceDao resourceDao = Mock()
-    GroupDao groupDao = new GroupDao(resourceDao: resourceDao)
+    GroupFilterParser filterParser = Mock()
+    GroupDao groupDao = new GroupDao(resourceDao, filterParser)
 
     def 'retrieving a group by id calls resourceDao.getById()'() {
         when:

--- a/src/test/groovy/org/osiam/storage/dao/UserDaoSpec.groovy
+++ b/src/test/groovy/org/osiam/storage/dao/UserDaoSpec.groovy
@@ -24,6 +24,7 @@
 package org.osiam.storage.dao
 
 import org.osiam.storage.entities.UserEntity
+import org.osiam.storage.query.UserFilterParser
 import spock.lang.Specification
 
 class UserDaoSpec extends Specification {
@@ -31,7 +32,8 @@ class UserDaoSpec extends Specification {
     static def IRRELEVANT = 'irrelevant'
 
     ResourceDao resourceDao = Mock()
-    UserDao userDao = new UserDao(resourceDao: resourceDao)
+    UserFilterParser filterParser = Mock()
+    UserDao userDao = new UserDao(filterParser, resourceDao)
 
     def 'retrieving a user by id calls resourceDao.getById()'() {
         when:


### PR DESCRIPTION
This is a code hygene PR. It does the following things:
- remove unnecessary usages of `StringBuilder` in `toString()` methods.
  The compiler does that for us.
- Move almost everything to constructor injection instead of field
  injection.
- The `NumberPadder` does not need to be a `@Service` it doesn't have
  any external dependencies. This commit turns it into a normal class
  that is instantiated by consuming classes.
- The `QueryFilterParser` does not need to be a `@Service` it doesn't
  have any external dependencies. The two consuming classes create their
  own local variables now.
