### PR TITLE
Better log message if auth-server can't be reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changes
 
+- Produce a meanigful log message and respond with `503 TEMPORARILY UNAVAILABLE`
+  instead of `409 CONFLICT` if the auth-server cannot be reached to validate or
+  revoke an access token.
 - All invalid search queries now respond with a `400 BAD REQUEST` instead of
   `409 CONFLICT` status code.
 - Update OSIAM connector4java

--- a/src/main/java/org/osiam/resources/exception/OsiamExceptionHandler.java
+++ b/src/main/java/org/osiam/resources/exception/OsiamExceptionHandler.java
@@ -25,6 +25,7 @@ package org.osiam.resources.exception;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import org.osiam.client.exception.ConnectionInitializationException;
 import org.osiam.resources.scim.ErrorResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,6 +68,13 @@ public class OsiamExceptionHandler extends ResponseEntityExceptionHandler {
     @ResponseBody
     public ErrorResponse handleBackendFailure(OsiamBackendFailureException e) {
         return produceErrorResponse("An internal error occurred", HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(ConnectionInitializationException.class)
+    @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+    @ResponseBody
+    public ErrorResponse handleBackendUnavailable(ConnectionInitializationException e) {
+        return produceErrorResponse("Service temporarily unavailable.", HttpStatus.SERVICE_UNAVAILABLE);
     }
 
     @ExceptionHandler({ResourceNotFoundException.class, NoSuchElementException.class})

--- a/src/test/groovy/org/osiam/resources/exception/OsiamExceptionHandlerSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/exception/OsiamExceptionHandlerSpec.groovy
@@ -24,6 +24,7 @@
 package org.osiam.resources.exception
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.osiam.client.exception.ConnectionInitializationException
 import org.osiam.resources.scim.User
 import org.springframework.http.HttpStatus
 import spock.lang.Specification
@@ -38,7 +39,7 @@ class OsiamExceptionHandlerSpec extends Specification {
         when:
         def result = exceptionHandler.defaultExceptionHandler(new NullPointerException(IRRELEVANT))
         then:
-        result.status == HttpStatus.CONFLICT.toString()
+        result.status == HttpStatus.CONFLICT as String
         result.detail == "An unexpected error occurred"
     }
 
@@ -46,23 +47,31 @@ class OsiamExceptionHandlerSpec extends Specification {
         when:
         def result = exceptionHandler.handleInvalidConstraintException(new InvalidConstraintException(IRRELEVANT))
         then:
-        result.detail == "Constraint ${IRRELEVANT} is invalid"
-        result.status == HttpStatus.BAD_REQUEST.toString()
+        result.detail == "Constraint ${IRRELEVANT} is invalid" as String
+        result.status == HttpStatus.BAD_REQUEST as String
     }
 
-    def 'status is set to INTERNAL_SERVER_ERROR when BackendFailureException occurs'() {
+    def 'status is set to INTERNAL_SERVER_ERROR when OsiamBackendFailureException occurs'() {
         when:
         def result = exceptionHandler.handleBackendFailure(new OsiamBackendFailureException())
         then:
         result.detail == "An internal error occurred"
-        result.status == HttpStatus.INTERNAL_SERVER_ERROR.toString()
+        result.status == HttpStatus.INTERNAL_SERVER_ERROR as String
+    }
+
+    def 'status is set to SERVICE_uNAVAILABLE when ConnectionInitialization occurs'() {
+        when:
+        def result = exceptionHandler.handleBackendUnavailable(new ConnectionInitializationException(IRRELEVANT))
+        then:
+        result.detail == "Service temporarily unavailable."
+        result.status == HttpStatus.SERVICE_UNAVAILABLE as String
     }
 
     def 'status is set to CONFLICT when ResourceExistsException occurs'() {
         when:
         def result = exceptionHandler.handleResourceExists(new ResourceExistsException(IRRELEVANT))
         then:
-        result.status == HttpStatus.CONFLICT.toString()
+        result.status == HttpStatus.CONFLICT as String
         result.detail == IRRELEVANT
     }
 
@@ -70,7 +79,7 @@ class OsiamExceptionHandlerSpec extends Specification {
         when:
         def result = exceptionHandler.handleResourceNotFoundException(new ResourceNotFoundException(IRRELEVANT))
         then:
-        result.status == HttpStatus.NOT_FOUND.toString()
+        result.status == HttpStatus.NOT_FOUND as String
         result.detail == IRRELEVANT
     }
 
@@ -78,7 +87,7 @@ class OsiamExceptionHandlerSpec extends Specification {
         when:
         def result = exceptionHandler.handleUnsupportedOperation(new UnsupportedOperationException(IRRELEVANT))
         then:
-        result.status == HttpStatus.NOT_IMPLEMENTED.toString()
+        result.status == HttpStatus.NOT_IMPLEMENTED as String
         result.detail == IRRELEVANT
     }
 
@@ -86,7 +95,7 @@ class OsiamExceptionHandlerSpec extends Specification {
         when:
         def result = exceptionHandler.handleSchemaUnknown(new SchemaUnknownException())
         then:
-        result.status == HttpStatus.I_AM_A_TEAPOT.toString()
+        result.status == HttpStatus.I_AM_A_TEAPOT as String
     }
 
     def "should transform json property invalid error message to a more readable response"() {
@@ -95,7 +104,7 @@ class OsiamExceptionHandlerSpec extends Specification {
         when:
         def result = exceptionHandler.handleUnrecognizedProperty(e)
         then:
-        result.status == HttpStatus.CONFLICT.toString()
+        result.status == HttpStatus.CONFLICT as String
         result.detail == 'Unrecognized field "extId"'
     }
 
@@ -106,7 +115,7 @@ class OsiamExceptionHandlerSpec extends Specification {
         def result = exceptionHandler.handleJsonMapping(e)
         then:
         result.detail == 'Can not deserialize instance of java.util.ArrayList out of VALUE_STRING'
-        result.status == HttpStatus.CONFLICT.toString()
+        result.status == HttpStatus.CONFLICT as String
     }
 
     Exception generate_wrong_json_exception(String input, Class clazz) {

--- a/src/test/groovy/org/osiam/security/authorization/AccessTokenValidationServiceTest.groovy
+++ b/src/test/groovy/org/osiam/security/authorization/AccessTokenValidationServiceTest.groovy
@@ -1,0 +1,52 @@
+package org.osiam.security.authorization
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.Appender
+import ch.qos.logback.core.spi.AppenderAttachable
+import org.osiam.client.OsiamConnector
+import org.osiam.client.exception.ConnectionInitializationException
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import spock.lang.Specification
+
+class AccessTokenValidationServiceTest extends Specification {
+
+    public static final String IRRELEVANT = 'irrelevant'
+    public static final String MESSAGE = 'message'
+
+    def appender = Mock(Appender)
+    def rootLogger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)
+    def connector = Mock(OsiamConnector)
+
+    def accessTokenValidator = new AccessTokenValidationService(IRRELEVANT)
+
+    def setup() {
+        ((AppenderAttachable<ILoggingEvent>) rootLogger).addAppender(appender)
+        accessTokenValidator.connector = connector
+    }
+
+    def 'failure to connect to auth-server when revoking an access token is logged'() {
+        when:
+        accessTokenValidator.revokeAccessTokens(IRRELEVANT, IRRELEVANT)
+
+        then:
+        1 * connector.revokeAllAccessTokens(_,_) >> { throw new ConnectionInitializationException(MESSAGE) }
+        1 * appender.doAppend({
+            it.message == "Unable to revoke access token on auth-server $IRRELEVANT: $MESSAGE"
+        })
+        thrown(ConnectionInitializationException)
+    }
+
+    def 'failure to connect to auth-server when validating an access token is logged'() {
+
+        when:
+        accessTokenValidator.loadAuthentication(IRRELEVANT)
+
+        then:
+        1 * connector.validateAccessToken(_) >> { throw new ConnectionInitializationException(MESSAGE) }
+        1 * appender.doAppend({
+            it.message == "Unable to retrieve access token from auth-server $IRRELEVANT: $MESSAGE"
+        })
+        thrown(ConnectionInitializationException)
+    }
+}


### PR DESCRIPTION
Provide a meaningful log message if the auth-server cannot be reached to
validate a provided access token.

This commit also turns the connector in the
`AccessTokenValidationService` into a field instead of creating it for
every request.

It adds one test for the code added, however the whole class lacks
tests, we should add them.

Fixes #52.
