### PR TITLE
Don't modify scim-schema objects internals

### DIFF
--- a/src/test/groovy/org/osiam/resources/converter/GroupConverterSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/converter/GroupConverterSpec.groovy
@@ -170,20 +170,15 @@ class GroupConverterSpec extends Specification {
     }
 
     def Group getFilledGroup(UUID uuid) {
-
-        Group.Builder groupBuilder = new Group.Builder(fixtures)
-
-        groupBuilder.setId(uuid.toString())
-        return groupBuilder.build()
+        return new Group.Builder(fixtures)
+                .setId(uuid as String)
+                .build()
     }
 
     def Group getFilledGroupWithMember(def uuid, def memberUuid) {
-        Group group = getFilledGroup(uuid)
-
-        MemberRef member = new MemberRef.Builder(value: memberUuid).build()
-
-        group.members.add(member)
-
-        return group
+        return new Group.Builder(fixtures)
+                .addMember(new MemberRef.Builder(value: memberUuid).build())
+                .setId(uuid as String)
+                .build()
     }
 }

--- a/src/test/groovy/org/osiam/resources/helper/JsonInputValidatorSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/helper/JsonInputValidatorSpec.groovy
@@ -34,7 +34,7 @@ class JsonInputValidatorSpec extends Specification {
 
     def jsonInputValidator = new JsonInputValidator()
     HttpServletRequest httpServletRequestMock
-    BufferedReader readerMock = Mock()
+    def readerMock = Mock(BufferedReader)
 
     def setup() {
         servletRequestWithMethod 'POST'
@@ -62,18 +62,6 @@ class JsonInputValidatorSpec extends Specification {
 
         then:
         thrown(IllegalArgumentException)
-    }
-
-    def 'missing mandatory schema declaration for user raises exception'() {
-        given:
-        def userJson = '{"userName" : "irrelevant"}'
-        readerMock.readLine() >>> [userJson, null]
-
-        when:
-        jsonInputValidator.validateJsonUser(httpServletRequestMock)
-
-        then:
-        thrown(JsonMappingException)
     }
 
     def 'using PATCH without userName field works'() {


### PR DESCRIPTION
While preparing to make the scim-schema objects immutable, these two
tests were discovered that accessed the internals of scim classes. It
also removes an unnecessary test.
