### PR TITLE
Increase timeouts and parallel connections to auth-server

### DIFF
--- a/src/main/java/org/osiam/security/authorization/AccessTokenValidationService.java
+++ b/src/main/java/org/osiam/security/authorization/AccessTokenValidationService.java
@@ -55,10 +55,19 @@ public class AccessTokenValidationService implements ResourceServerTokenServices
 
     private OsiamConnector connector;
 
+    static {
+        OsiamConnector.setMaxConnections(40);
+        OsiamConnector.setMaxConnectionsPerRoute(40);
+    }
+
     @Autowired
     public AccessTokenValidationService(@Value("${org.osiam.auth-server.home}") String authServerHome) {
         this.authServerHome = authServerHome;
-        this.connector = new OsiamConnector.Builder().setAuthServerEndpoint(authServerHome).build();
+        this.connector = new OsiamConnector.Builder()
+                .setAuthServerEndpoint(authServerHome)
+                .withReadTimeout(10000)
+                .withConnectTimeout(5000)
+                .build();
     }
 
     @Override


### PR DESCRIPTION
We had some issues with too many parallel request to the resource-server. It turned out that requests to the auth-server, which are necessary to validate the access token, queue up in the HTTP connection pool queue, which leads to timeouts on the client side of the original request.
