### PR TITLE
Don't access member property of Group directly

### DIFF
--- a/src/test/groovy/org/osiam/resources/converter/GroupConverterSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/converter/GroupConverterSpec.groovy
@@ -171,19 +171,16 @@ class GroupConverterSpec extends Specification {
 
     def Group getFilledGroup(UUID uuid) {
 
-        Group.Builder groupBuilder = new Group.Builder(fixtures)
-
-        groupBuilder.setId(uuid.toString())
-        return groupBuilder.build()
+        return new Group.Builder(fixtures)
+                .setId(uuid as String)
+                .build()
     }
 
     def Group getFilledGroupWithMember(def uuid, def memberUuid) {
-        Group group = getFilledGroup(uuid)
 
-        MemberRef member = new MemberRef.Builder(value: memberUuid).build()
-
-        group.members.add(member)
-
-        return group
+        return new Group.Builder(fixtures)
+                .setId(uuid as String)
+                .addMember(new MemberRef.Builder(value: memberUuid).build())
+                .build()
     }
 }


### PR DESCRIPTION
Don't access the member property directly. To prepare for the
scim-schema to become completely immutable prevent this test to access
the members property directly.

This pull-request is in preparation of osiam/scim-schema#126 but needs to be merged after osiam/scim-schema#161 has been merged.
