### PR TITLE
Extend configuration by parameters for pools and timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Make connector properties configurable
+- Make JDBC pool properties configurable
 
 ## 2.3 - 2015-10-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # OSIAM resource server
 
+## 2.4 - Unreleased
+
+### Features
+
+- Make connector properties configurable
+
 ## 2.3 - 2015-10-09
 
 ### Features

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,8 +12,13 @@ org.osiam.resource-server.home=http://localhost:8080/osiam-resource-server
 # ATTENTION: you have to set a random secret for the resource server client!
 #org.osiam.resource-server.client.secret=
 
-# OSIAM auth server configuration
+# OSIAM auth-server configuration
 org.osiam.auth-server.home=http://localhost:8080/osiam-auth-server
+# Maximum number of parallel connections to the auth-server
+org.osiam.auth-server.connector.max-connections=40
+# Timeouts of connections to auth-server in milliseconds
+org.osiam.auth-server.connector.read-timeout-ms=10000
+org.osiam.auth-server.connector.connect-timeout-ms=5000
 ```
 
 The example properties file can also be found on [GitHub](https://github.com/osiam/server/blob/master/resource-server/src/main/deploy/resource-server.properties).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,10 @@ org.osiam.auth-server.connector.max-connections=40
 # Timeouts of connections to auth-server in milliseconds
 org.osiam.auth-server.connector.read-timeout-ms=10000
 org.osiam.auth-server.connector.connect-timeout-ms=5000
+
+# JDBC pool properties
+org.osiam.resource-server.db.maximum-pool-size=10
+org.osiam.resource-server.db.connection-timeout-ms=30000
 ```
 
 The example properties file can also be found on [GitHub](https://github.com/osiam/server/blob/master/resource-server/src/main/deploy/resource-server.properties).

--- a/src/main/deploy/resource-server.properties
+++ b/src/main/deploy/resource-server.properties
@@ -6,6 +6,10 @@ org.osiam.resource-server.db.url=jdbc:postgresql://localhost:5432/ong
 org.osiam.resource-server.db.username=ong
 org.osiam.resource-server.db.password=b4s3dg0d
 
+# JDBC pool properties
+org.osiam.resource-server.db.maximum-pool-size=10
+org.osiam.resource-server.db.connection-timeout-ms=30000
+
 # OSIAM resource server configuration
 org.osiam.resource-server.profiling=false
 

--- a/src/main/deploy/resource-server.properties
+++ b/src/main/deploy/resource-server.properties
@@ -12,5 +12,10 @@ org.osiam.resource-server.profiling=false
 # Home URL (needed for self reference)
 org.osiam.resource-server.home=http://localhost:8080/osiam-resource-server
 
-# OSIAM auth server configuration
+# OSIAM auth-server configuration
 org.osiam.auth-server.home=http://localhost:8080/osiam-auth-server
+# Maximum number of parallel connections to the auth-server
+org.osiam.auth-server.connector.max-connections=40
+# Timeouts of connections to auth-server in milliseconds
+org.osiam.auth-server.connector.read-timeout-ms=10000
+org.osiam.auth-server.connector.connect-timeout-ms=5000

--- a/src/main/java/org/osiam/security/authorization/AccessTokenValidationService.java
+++ b/src/main/java/org/osiam/security/authorization/AccessTokenValidationService.java
@@ -27,6 +27,7 @@ import org.osiam.client.OsiamConnector;
 import org.osiam.client.oauth.AccessToken;
 import org.osiam.client.oauth.Scope;
 import org.osiam.resources.scim.User;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -44,16 +45,26 @@ import java.util.HashSet;
 import java.util.Set;
 
 @Service
-public class AccessTokenValidationService implements ResourceServerTokenServices {
+public class AccessTokenValidationService implements ResourceServerTokenServices, InitializingBean {
 
     @Value("${org.osiam.auth-server.home}")
     private String authServerHome;
 
-    static {
-        OsiamConnector.setMaxConnections(40);
-        OsiamConnector.setMaxConnectionsPerRoute(40);
-        OsiamConnector.setReadTimeout(10000);
-        OsiamConnector.setConnectTimeout(5000);
+    @Value("${org.osiam.auth-server.connector.max-connections:40}")
+    private int maxConnections;
+
+    @Value("${org.osiam.auth-server.connector.read-timeout-ms:10000}")
+    private int readTimeout;
+
+    @Value("${org.osiam.auth-server.connector.connect-timeout-ms:5000}")
+    private int connectTimeout;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        OsiamConnector.setMaxConnections(maxConnections);
+        OsiamConnector.setMaxConnectionsPerRoute(maxConnections);
+        OsiamConnector.setReadTimeout(readTimeout);
+        OsiamConnector.setConnectTimeout(connectTimeout);
     }
 
     @Override

--- a/src/main/webapp/WEB-INF/jpa-configuration.xml
+++ b/src/main/webapp/WEB-INF/jpa-configuration.xml
@@ -56,6 +56,10 @@
         <property name="driverClassName" value="${org.osiam.resource-server.db.driver}" />
         <property name="username" value="${org.osiam.resource-server.db.username}" />
         <property name="password" value="${org.osiam.resource-server.db.password}" />
+        <property name="connectionTimeout"
+                  value="${org.osiam.resource-server.db.connection-timeout-ms:30000}"/>
+        <property name="maximumPoolSize"
+                  value="${org.osiam.resource-server.db.maximum-pool-size:10}"/>
     </bean>
 
     <bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">


### PR DESCRIPTION
This is part of the efforts to support more parallel requests. See also #92.

Resolves #92
