### PR TITLE
Prevent direct access to scim-schema object fields

### DIFF
--- a/src/test/groovy/org/osiam/resources/converter/UserConverterSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/converter/UserConverterSpec.groovy
@@ -43,19 +43,19 @@ class UserConverterSpec extends Specification {
                     userType         : 'userType',
                     active           : true]
 
-    X509CertificateConverter x509CertificateConverter = Mock()
-    RoleConverter roleConverter = Mock()
-    PhotoConverter photoConverter = Mock()
-    PhoneNumberConverter phoneNumberConverter = Mock()
-    ImConverter imConverter = Mock()
-    EntitlementConverter entitlementConverter = Mock()
-    EmailConverter emailConverter = Mock()
-    AddressConverter addressConverter = Mock()
-    NameConverter nameConverter = Mock()
-    ExtensionConverter extensionConverter = Mock()
-    MetaConverter metaConverter = Mock()
+    def x509CertificateConverter = Mock(X509CertificateConverter)
+    def roleConverter = Mock(RoleConverter)
+    def photoConverter = Mock(PhotoConverter)
+    def phoneNumberConverter = Mock(PhoneNumberConverter)
+    def imConverter = Mock(ImConverter)
+    def entitlementConverter = Mock(EntitlementConverter)
+    def emailConverter = Mock(EmailConverter)
+    def addressConverter = Mock(AddressConverter)
+    def nameConverter = Mock(NameConverter)
+    def extensionConverter = Mock(ExtensionConverter)
+    def metaConverter = Mock(MetaConverter)
 
-    UserDao userDao = Mock()
+    def userDao = Mock(UserDao)
 
     UserConverter userConverter = new UserConverter(
             x509CertificateConverter: x509CertificateConverter,
@@ -82,16 +82,16 @@ class UserConverterSpec extends Specification {
 
         then:
         1 * extensionConverter.toScim(_) >> ([] as Set<Extension>)
-        1 * x509CertificateConverter.toScim(_) >> ([] as Set)
-        1 * roleConverter.toScim(_) >> ([] as Set)
-        1 * photoConverter.toScim(_) >> ([] as Set)
-        1 * phoneNumberConverter.toScim(_) >> ([] as Set)
-        1 * imConverter.toScim(_) >> ([] as Set)
-        1 * entitlementConverter.toScim(_) >> ([] as Set)
-        1 * emailConverter.toScim(_) >> ([] as Set)
-        1 * addressConverter.toScim(_) >> ([] as Set)
-        1 * nameConverter.toScim(_) >> (new Name())
-        1 * metaConverter.toScim(_) >> (new Meta())
+        1 * x509CertificateConverter.toScim(_) >> (new X509Certificate.Builder().build())
+        1 * roleConverter.toScim(_) >> (new Role.Builder().build())
+        1 * photoConverter.toScim(_) >> (new Photo.Builder().build())
+        1 * phoneNumberConverter.toScim(_) >> (new PhoneNumber.Builder().build())
+        1 * imConverter.toScim(_) >> (new Im.Builder().build())
+        1 * entitlementConverter.toScim(_) >> (new Entitlement.Builder().build())
+        1 * emailConverter.toScim(_) >> (new Email.Builder().build())
+        1 * addressConverter.toScim(_) >> (new Address.Builder().build())
+        1 * nameConverter.toScim(_) >> (new Name.Builder().build())
+        1 * metaConverter.toScim(_) >> (new Meta.Builder().build())
 
         user.id == uuid.toString()
         user.isActive()
@@ -129,7 +129,7 @@ class UserConverterSpec extends Specification {
         1 * addressConverter.fromScim(_) >> ([] as Set)
         1 * nameConverter.fromScim(_) >> new NameEntity()
 
-        userEntity.active == true
+        userEntity.active
         userEntity.displayName == fixtures["displayName"]
         userEntity.externalId == fixtures["externalId"]
         userEntity.locale == fixtures["locale"]
@@ -163,21 +163,21 @@ class UserConverterSpec extends Specification {
         UserEntity userEntity = userConverter.fromScim(user)
 
         then:
-        userEntity.getActive() == false
+        !userEntity.getActive()
     }
 
     def User getFilledUser(UUID internalId) {
         User.Builder userBuilder = new User.Builder(fixtures)
         userBuilder.setId(internalId.toString())
 
-        userBuilder.addX509Certificates([Mock(X509Certificate)] as List<X509Certificate>)
-        userBuilder.addRoles([Mock(Role)] as List<Role>)
-        userBuilder.addEmails([Mock(Email)] as List<Email>)
-        userBuilder.addEntitlements([Mock(Entitlement)] as List<Entitlement>)
-        userBuilder.addPhoneNumbers([Mock(PhoneNumber)] as List<PhoneNumber>)
-        userBuilder.addPhotos([Mock(Photo)] as List<Photo>)
-        userBuilder.addIms([Mock(Im)] as List<Im>)
-        userBuilder.addAddresses([Mock(Address)] as List<Address>)
+        userBuilder.addX509Certificates([new X509Certificate.Builder().build()] as List<X509Certificate>)
+        userBuilder.addRoles([new Role.Builder().build()] as List<Role>)
+        userBuilder.addEmails([new Email.Builder().build()] as List<Email>)
+        userBuilder.addEntitlements([new Entitlement.Builder().build()] as List<Entitlement>)
+        userBuilder.addPhoneNumbers([new PhoneNumber.Builder().build()] as List<PhoneNumber>)
+        userBuilder.addPhotos([new Photo.Builder().build()] as List<Photo>)
+        userBuilder.addIms([new Im.Builder().build()] as List<Im>)
+        userBuilder.addAddresses([new Address.Builder().build()] as List<Address>)
 
         return userBuilder.build()
     }

--- a/src/test/groovy/org/osiam/resources/provisioning/SCIMGroupProvisioningBeanSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/provisioning/SCIMGroupProvisioningBeanSpec.groovy
@@ -38,14 +38,14 @@ import javax.persistence.NoResultException
 
 class SCIMGroupProvisioningBeanSpec extends Specification {
 
-    GroupDao groupDao = Mock()
-    GroupConverter groupConverter = Mock()
-    GroupUpdater groupUpdater = Mock()
+    def groupDao = Mock(GroupDao)
+    def groupConverter = Mock(GroupConverter)
+    def groupUpdater = Mock(GroupUpdater)
 
-    SCIMGroupProvisioning scimGroupProvisioning = new SCIMGroupProvisioning(groupDao: groupDao, groupConverter: groupConverter,
+    def scimGroupProvisioning = new SCIMGroupProvisioning(groupDao: groupDao, groupConverter: groupConverter,
             groupUpdater: groupUpdater)
 
-    Group group = Mock()
+    Group group = new Group.Builder().build()
     GroupEntity groupEntity = Mock()
 
     def groupUuid = UUID.randomUUID().toString()

--- a/src/test/groovy/org/osiam/resources/provisioning/update/GroupUpdaterSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/provisioning/update/GroupUpdaterSpec.groovy
@@ -38,13 +38,13 @@ class GroupUpdaterSpec extends Specification {
 
     static IRRELEVANT = 'irrelevant'
 
-    ResourceUpdater resourceUpdater = Mock()
-    ResourceDao resourceDao = Mock()
-    GroupDao groupDao = Mock()
-    GroupUpdater groupUpdater = new GroupUpdater(groupDao, resourceUpdater, resourceDao)
+    def resourceUpdater = Mock(ResourceUpdater)
+    def resourceDao = Mock(ResourceDao)
+    def groupDao = Mock(GroupDao)
+    def groupUpdater = new GroupUpdater(groupDao, resourceUpdater, resourceDao)
 
     Group group
-    GroupEntity groupEntity = Mock()
+    def groupEntity = Mock(GroupEntity)
 
     def 'updating a group triggers resource updater'() {
         given:
@@ -59,7 +59,7 @@ class GroupUpdaterSpec extends Specification {
 
     def 'removing displayName is not possible'() {
         given:
-        Meta meta = new Meta(attributes: ['displayName'] as Set)
+        Meta meta = new Meta.Builder(attributes: ['displayName'] as Set).build()
         group = new Group.Builder(meta: meta).build()
 
         when:
@@ -103,7 +103,7 @@ class GroupUpdaterSpec extends Specification {
 
     def 'removing all members is possible'() {
         given:
-        Meta meta = new Meta(attributes: ['members'] as Set)
+        Meta meta = new Meta.Builder(attributes: ['members'] as Set).build()
         group = new Group.Builder(meta: meta).build()
 
         when:

--- a/src/test/groovy/org/osiam/resources/provisioning/update/NameUpdaterSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/provisioning/update/NameUpdaterSpec.groovy
@@ -33,65 +33,68 @@ class NameUpdaterSpec extends Specification {
 
     static IRRELEVANT = 'irrelevant'
 
-    Name name
-    UserEntity userEntity = Mock()
-    NameEntity nameEntity = Mock()
     NameUpdater nameUpdater = new NameUpdater()
 
     def 'removing the name attribute is possible'() {
+        given:
+        def userEntity = new UserEntity(name: new NameEntity())
+
         when:
         nameUpdater.update(null, userEntity, ['name'] as Set)
 
         then:
-        1 * userEntity.setName(null)
+        userEntity.name == null
     }
 
     def 'updating the name if at least one sub-attribute is set and the user entity has no name set, creates a new name entity'() {
         given:
-        userEntity = new UserEntity()
-        name = new Name(formatted: IRRELEVANT)
+        def userEntity = new UserEntity()
+        def name = new Name.Builder(formatted: IRRELEVANT).build()
 
         when:
         nameUpdater.update(name, userEntity, [] as Set)
 
         then:
-        userEntity.getName() != null
+        userEntity.name.formatted == IRRELEVANT
     }
 
     def 'deleting the formatted attribute is possible'() {
         given:
-        userEntity = new UserEntity(name: nameEntity)
+        def nameEntity = new NameEntity()
+        def userEntity = new UserEntity(name: nameEntity)
 
         when:
         nameUpdater.update(null, userEntity, ['name.formatted'] as Set)
 
         then:
-        1 * nameEntity.setFormatted(null)
+        nameEntity.formatted == null
     }
 
     def 'updating the formatted attribute is possible'() {
         given:
-        userEntity = new UserEntity(name: nameEntity)
-        name = new Name(formatted: IRRELEVANT)
+        def nameEntity = new NameEntity()
+        def userEntity = new UserEntity(name: nameEntity)
+        def name = new Name.Builder(formatted: IRRELEVANT).build()
 
         when:
         nameUpdater.update(name, userEntity, [] as Set)
 
         then:
-        1 * nameEntity.setFormatted(IRRELEVANT)
+        nameEntity.formatted == IRRELEVANT
     }
 
     @Unroll
     def 'updating formatted attribute to #value is not possible'() {
         given:
-        userEntity = new UserEntity(name: nameEntity)
-        name = new Name(formatted: formatted)
+        def nameEntity = new NameEntity(formatted: IRRELEVANT)
+        def userEntity = new UserEntity(name: nameEntity)
+        def name = new Name.Builder(formatted: formatted).build()
 
         when:
         nameUpdater.update(name, userEntity, [] as Set)
 
         then:
-        0 * nameEntity.setFormatted(_)
+        nameEntity.formatted != value
 
         where:
         value          | formatted
@@ -101,38 +104,41 @@ class NameUpdaterSpec extends Specification {
 
     def 'deleting the familyName attribute is possible'() {
         given:
-        userEntity = new UserEntity(name: nameEntity)
+        def nameEntity = new NameEntity(familyName: IRRELEVANT)
+        def userEntity = new UserEntity(name: nameEntity)
 
         when:
         nameUpdater.update(null, userEntity, ['name.familyName'] as Set)
 
         then:
-        1 * nameEntity.setFamilyName(null)
+        nameEntity.familyName == null
     }
 
     def 'updating the familyName attribute is possible'() {
         given:
-        userEntity = new UserEntity(name: nameEntity)
-        name = new Name(familyName: IRRELEVANT)
+        def nameEntity = new NameEntity()
+        def userEntity = new UserEntity(name: nameEntity)
+        def name = new Name.Builder(familyName: IRRELEVANT).build()
 
         when:
         nameUpdater.update(name, userEntity, [] as Set)
 
         then:
-        1 * nameEntity.setFamilyName(IRRELEVANT)
+        nameEntity.familyName == IRRELEVANT
     }
 
     @Unroll
     def 'updating familyName attribute to #value is not possible'() {
         given:
-        userEntity = new UserEntity(name: nameEntity)
-        name = new Name(familyName: familyName)
+        def nameEntity = new NameEntity(familyName: IRRELEVANT)
+        def userEntity = new UserEntity(name: nameEntity)
+        def name = new Name.Builder(familyName: familyName).build()
 
         when:
         nameUpdater.update(name, userEntity, [] as Set)
 
         then:
-        0 * nameEntity.setFamilyName(_)
+        nameEntity.familyName == IRRELEVANT
 
         where:
         value          | familyName
@@ -142,38 +148,41 @@ class NameUpdaterSpec extends Specification {
 
     def 'deleting the givenName attribute is possible'() {
         given:
-        userEntity = new UserEntity(name: nameEntity)
+        def nameEntity = new NameEntity(givenName: IRRELEVANT)
+        def userEntity = new UserEntity(name: nameEntity)
 
         when:
         nameUpdater.update(null, userEntity, ['name.givenName'] as Set)
 
         then:
-        1 * nameEntity.setGivenName(null)
+        nameEntity.givenName == null
     }
 
     def 'updating the givenName attribute is possible'() {
         given:
-        userEntity = new UserEntity(name: nameEntity)
-        name = new Name(givenName: IRRELEVANT)
+        def nameEntity = new NameEntity()
+        def userEntity = new UserEntity(name: nameEntity)
+        def name = new Name.Builder(givenName: IRRELEVANT).build()
 
         when:
         nameUpdater.update(name, userEntity, [] as Set)
 
         then:
-        1 * nameEntity.setGivenName(IRRELEVANT)
+        nameEntity.givenName == IRRELEVANT
     }
 
     @Unroll
     def 'updating givenName attribute to #value is not possible'() {
         given:
-        userEntity = new UserEntity(name: nameEntity)
-        name = new Name(givenName: givenName)
+        def nameEntity = new NameEntity(givenName: IRRELEVANT)
+        def userEntity = new UserEntity(name: nameEntity)
+        def name = new Name.Builder(givenName: givenName).build()
 
         when:
         nameUpdater.update(name, userEntity, [] as Set)
 
         then:
-        0 * nameEntity.setGivenName(_)
+        nameEntity.givenName == IRRELEVANT
 
         where:
         value          | givenName
@@ -183,38 +192,41 @@ class NameUpdaterSpec extends Specification {
 
     def 'deleting the middleName attribute is possible'() {
         given:
-        userEntity = new UserEntity(name: nameEntity)
+        def nameEntity = new NameEntity(middleName: IRRELEVANT)
+        def userEntity = new UserEntity(name: nameEntity)
 
         when:
         nameUpdater.update(null, userEntity, ['name.middleName'] as Set)
 
         then:
-        1 * nameEntity.setMiddleName(null)
+        nameEntity.middleName == null
     }
 
     def 'updating the middleName attribute is possible'() {
         given:
-        userEntity = new UserEntity(name: nameEntity)
-        name = new Name(middleName: IRRELEVANT)
+        def nameEntity = new NameEntity()
+        def userEntity = new UserEntity(name: nameEntity)
+        def name = new Name.Builder(middleName: IRRELEVANT).build()
 
         when:
         nameUpdater.update(name, userEntity, [] as Set)
 
         then:
-        1 * nameEntity.setMiddleName(IRRELEVANT)
+        nameEntity.middleName == IRRELEVANT
     }
 
     @Unroll
     def 'updating middleName attribute to #value is not possible'() {
         given:
-        userEntity = new UserEntity(name: nameEntity)
-        name = new Name(middleName: middleName)
+        def nameEntity = new NameEntity(middleName: IRRELEVANT)
+        def userEntity = new UserEntity(name: nameEntity)
+        def name = new Name.Builder(middleName: middleName).build()
 
         when:
         nameUpdater.update(name, userEntity, [] as Set)
 
         then:
-        0 * nameEntity.setMiddleName(_)
+        nameEntity.middleName == IRRELEVANT
 
         where:
         value          | middleName
@@ -224,38 +236,41 @@ class NameUpdaterSpec extends Specification {
 
     def 'deleting the honorificPrefix attribute is possible'() {
         given:
-        userEntity = new UserEntity(name: nameEntity)
+        def nameEntity = new NameEntity(honorificPrefix: IRRELEVANT)
+        def userEntity = new UserEntity(name: nameEntity)
 
         when:
         nameUpdater.update(null, userEntity, ['name.honorificPrefix'] as Set)
 
         then:
-        1 * nameEntity.setHonorificPrefix(null)
+        nameEntity.honorificPrefix == null
     }
 
     def 'updating the honorificPrefix attribute is possible'() {
         given:
-        userEntity = new UserEntity(name: nameEntity)
-        name = new Name(honorificPrefix: IRRELEVANT)
+        def nameEntity = new NameEntity()
+        def userEntity = new UserEntity(name: nameEntity)
+        def name = new Name.Builder(honorificPrefix: IRRELEVANT).build()
 
         when:
         nameUpdater.update(name, userEntity, [] as Set)
 
         then:
-        1 * nameEntity.setHonorificPrefix(IRRELEVANT)
+        nameEntity.honorificPrefix == IRRELEVANT
     }
 
     @Unroll
     def 'updating honorificPrefix attribute to #value is not possible'() {
         given:
-        userEntity = new UserEntity(name: nameEntity)
-        name = new Name(honorificPrefix: honorificPrefix)
+        def nameEntity = new NameEntity(honorificPrefix: IRRELEVANT)
+        def userEntity = new UserEntity(name: nameEntity)
+        def name = new Name.Builder(honorificPrefix: honorificPrefix).build()
 
         when:
         nameUpdater.update(name, userEntity, [] as Set)
 
         then:
-        0 * nameEntity.setHonorificPrefix(_)
+        nameEntity.honorificPrefix == IRRELEVANT
 
         where:
         value          | honorificPrefix
@@ -265,38 +280,41 @@ class NameUpdaterSpec extends Specification {
 
     def 'deleting the honorificSuffix attribute is possible'() {
         given:
-        userEntity = new UserEntity(name: nameEntity)
+        def nameEntity = new NameEntity(honorificSuffix: IRRELEVANT)
+        def userEntity = new UserEntity(name: nameEntity)
 
         when:
         nameUpdater.update(null, userEntity, ['name.honorificSuffix'] as Set)
 
         then:
-        1 * nameEntity.setHonorificSuffix(null)
+        nameEntity.honorificSuffix == null
     }
 
     def 'updating the honorificSuffix attribute is possible'() {
         given:
-        userEntity = new UserEntity(name: nameEntity)
-        name = new Name(honorificSuffix: IRRELEVANT)
+        def nameEntity = new NameEntity()
+        def userEntity = new UserEntity(name: nameEntity)
+        def name = new Name.Builder(honorificSuffix: IRRELEVANT).build()
 
         when:
         nameUpdater.update(name, userEntity, [] as Set)
 
         then:
-        1 * nameEntity.setHonorificSuffix(IRRELEVANT)
+        nameEntity.honorificSuffix == IRRELEVANT
     }
 
     @Unroll
     def 'updating honorificSuffix attribute to #value is not possible'() {
         given:
-        userEntity = new UserEntity(name: nameEntity)
-        name = new Name(honorificSuffix: honorificSuffix)
+        def nameEntity = new NameEntity(honorificSuffix: IRRELEVANT)
+        def userEntity = new UserEntity(name: nameEntity)
+        def name = new Name.Builder(honorificSuffix: honorificSuffix).build()
 
         when:
         nameUpdater.update(name, userEntity, [] as Set)
 
         then:
-        0 * nameEntity.setHonorificSuffix(_)
+        nameEntity.honorificSuffix == IRRELEVANT
 
         where:
         value          | honorificSuffix

--- a/src/test/groovy/org/osiam/resources/provisioning/update/ResourceUpdaterSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/provisioning/update/ResourceUpdaterSpec.groovy
@@ -34,43 +34,43 @@ class ResourceUpdaterSpec extends Specification {
 
     static String IRRELEVANT = 'irrelevant'
 
-    ResourceDao resourceDao = Mock()
+    def resourceDao = Mock(ResourceDao)
     ResourceUpdater resourceUpdater = new ResourceUpdater(resourceDao)
 
-    Meta metaWithAttributesToDelete = new Meta(attributes: ['externalId'] as Set)
+    Meta metaWithAttributesToDelete = new Meta.Builder(attributes: ['externalId'] as Set).build()
     // resources are abstract so we use groups here with no loss of generality
     Group group
-    GroupEntity groupEntity = Mock()
 
     def 'removing externalId works'() {
         given:
         group = new Group.Builder(meta: metaWithAttributesToDelete).build()
+        def groupEntity = new GroupEntity(externalId: IRRELEVANT)
 
         when:
         resourceUpdater.update(group, groupEntity)
 
         then:
-        1 * groupEntity.setExternalId(null)
+        groupEntity.externalId == null
     }
 
     def 'updating externalId works'() {
         given:
         def uuid = UUID.randomUUID()
         group = new Group.Builder(externalId: IRRELEVANT).build()
-        groupEntity.getId() >> uuid
+        def groupEntity = new GroupEntity(id: uuid)
 
         when:
         resourceUpdater.update(group, groupEntity)
 
         then:
-        1 * groupEntity.setExternalId(IRRELEVANT)
+        groupEntity.externalId == IRRELEVANT
     }
 
     def 'updating the externalId checks if the externalId already exists'() {
         given:
         def uuid = UUID.randomUUID()
         Group group = new Group.Builder(externalId: IRRELEVANT).build()
-        groupEntity.getId() >> uuid
+        def groupEntity = new GroupEntity(id: uuid)
 
         when:
         resourceUpdater.update(group, groupEntity)
@@ -83,7 +83,7 @@ class ResourceUpdaterSpec extends Specification {
         given:
         def uuid = UUID.randomUUID()
         Group group = new Group.Builder(externalId: IRRELEVANT).build()
-        groupEntity.getId() >> uuid
+        def groupEntity = new GroupEntity(id: uuid)
 
         when:
         resourceUpdater.update(group, groupEntity)

--- a/src/test/groovy/org/osiam/resources/provisioning/update/UserUpdaterSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/provisioning/update/UserUpdaterSpec.groovy
@@ -82,7 +82,7 @@ class UserUpdaterSpec extends Specification {
 
     def 'removing the userName attribute raises exception'() {
         given:
-        Meta meta = new Meta(attributes: ['userName'] as Set)
+        Meta meta = new Meta.Builder(attributes: ['userName'] as Set).build()
         user = new User.Builder(meta: meta).build()
 
         when:
@@ -235,7 +235,7 @@ class UserUpdaterSpec extends Specification {
 
     def 'removing the displayName attribute is possible'() {
         given:
-        Meta meta = new Meta(attributes: ['displayName'] as Set)
+        Meta meta = new Meta.Builder(attributes: ['displayName'] as Set).build()
         user = new User.Builder(meta: meta).build()
 
         when:
@@ -275,7 +275,7 @@ class UserUpdaterSpec extends Specification {
 
     def 'removing the nickName attribute is possible'() {
         given:
-        Meta meta = new Meta(attributes: ['nickName'] as Set)
+        Meta meta = new Meta.Builder(attributes: ['nickName'] as Set).build()
         user = new User.Builder(meta: meta).build()
 
         when:
@@ -315,7 +315,7 @@ class UserUpdaterSpec extends Specification {
 
     def 'removing the profileUrl attribute is possible'() {
         given:
-        Meta meta = new Meta(attributes: ['profileUrl'] as Set)
+        Meta meta = new Meta.Builder(attributes: ['profileUrl'] as Set).build()
         user = new User.Builder(meta: meta).build()
 
         when:
@@ -355,7 +355,7 @@ class UserUpdaterSpec extends Specification {
 
     def 'removing the title attribute is possible'() {
         given:
-        Meta meta = new Meta(attributes: ['title'] as Set)
+        Meta meta = new Meta.Builder(attributes: ['title'] as Set).build()
         user = new User.Builder(meta: meta).build()
 
         when:
@@ -395,7 +395,7 @@ class UserUpdaterSpec extends Specification {
 
     def 'removing the userType attribute is possible'() {
         given:
-        Meta meta = new Meta(attributes: ['userType'] as Set)
+        Meta meta = new Meta.Builder(attributes: ['userType'] as Set).build()
         user = new User.Builder(meta: meta).build()
 
         when:
@@ -435,7 +435,7 @@ class UserUpdaterSpec extends Specification {
 
     def 'removing the preferredLanguage attribute is possible'() {
         given:
-        Meta meta = new Meta(attributes: ['preferredLanguage'] as Set)
+        Meta meta = new Meta.Builder(attributes: ['preferredLanguage'] as Set).build()
         user = new User.Builder(meta: meta).build()
 
         when:
@@ -475,7 +475,7 @@ class UserUpdaterSpec extends Specification {
 
     def 'removing the locale attribute is possible'() {
         given:
-        Meta meta = new Meta(attributes: ['locale'] as Set)
+        Meta meta = new Meta.Builder(attributes: ['locale'] as Set).build()
         user = new User.Builder(meta: meta).build()
 
         when:
@@ -515,7 +515,7 @@ class UserUpdaterSpec extends Specification {
 
     def 'removing the timezone attribute is possible'() {
         given:
-        Meta meta = new Meta(attributes: ['timezone'] as Set)
+        Meta meta = new Meta.Builder(attributes: ['timezone'] as Set).build()
         user = new User.Builder(meta: meta).build()
 
         when:
@@ -555,7 +555,7 @@ class UserUpdaterSpec extends Specification {
 
     def 'removing the active attribute is possible'() {
         given:
-        Meta meta = new Meta(attributes: ['active'] as Set)
+        Meta meta = new Meta.Builder(attributes: ['active'] as Set).build()
         user = new User.Builder(meta: meta).build()
 
         when:
@@ -594,7 +594,7 @@ class UserUpdaterSpec extends Specification {
 
     def 'removing the password attribute raises exception'() {
         given:
-        Meta meta = new Meta(attributes: ['password'] as Set)
+        Meta meta = new Meta.Builder(attributes: ['password'] as Set).build()
         user = new User.Builder(meta: meta).build()
 
         when:
@@ -638,7 +638,7 @@ class UserUpdaterSpec extends Specification {
 
     def 'deleting all groups raises an exception'() {
         given:
-        Meta meta = new Meta(attributes: ['groups'] as Set)
+        Meta meta = new Meta.Builder(attributes: ['groups'] as Set).build()
         user = new User.Builder(meta: meta).build()
 
         when:
@@ -651,7 +651,7 @@ class UserUpdaterSpec extends Specification {
 
     def 'modify a single group raises an exception'() {
         given:
-        user = new User.Builder(groups: [new Group()] as List).build()
+        user = new User.Builder(groups: [new Group.Builder().build()] as List).build()
 
         when:
         userUpdater.update(user, userEntity)


### PR DESCRIPTION
In preparation to making scim-schema completely immutable this commit
prevents all Spock tests from accessing the fields of scim-schema
objects directly. It also does some house keeping and in the tests 
and makes some Spock specifications a little more 'Groovy'.
